### PR TITLE
Fix error recovery when archinstall fails

### DIFF
--- a/builder/cmds/autostart.sh
+++ b/builder/cmds/autostart.sh
@@ -21,12 +21,13 @@ trap catch_errors ERR
 if [[ $(tty) == "/dev/tty1" ]]; then
   NETWORK_NEEDED=1 ./installer
 
+  # Get username from installer config for reliable error recovery
+  OMARCHY_USER="$(jq -r '.users[0].username' user_credentials.json)"
+
   archinstall \
     --config user_configuration.json \
     --creds user_credentials.json \
     --silent
-
-  OMARCHY_USER="$(ls -1 /mnt/home | head -n1)"
 
   # No need to ask for sudo during the installation (omarchy itself responsible for removing after install)
   mkdir -p /mnt/etc/sudoers.d


### PR DESCRIPTION
Fixes the issue where error recovery doesn't work when archinstall fails.

**Problem**: When archinstall fails, `/mnt/home` doesn't exist, so `OMARCHY_USER` becomes empty and the recovery chroot never executes.

**Solution**: Get username from installer JSON config instead of filesystem state.

This builds on David's excellent error trapping framework and ensures recovery works even when archinstall completely fails.