### PR TITLE
omarchy-iso-boot: command not found

### DIFF
--- a/bin/omarchy-iso-make
+++ b/bin/omarchy-iso-make
@@ -43,4 +43,4 @@ sudo chmod 777 -R "$BUILD_RELEASE_PATH"
 # Offer to boot the new build
 echo
 latest_iso=$(\ls -t "$BUILD_RELEASE_PATH"/*.iso | head -n1)
-gum confirm "Boot $latest_iso?" && omarchy-iso-boot "$latest_iso"
+gum confirm "Boot $latest_iso?" && bin/omarchy-iso-boot "$latest_iso"


### PR DESCRIPTION
Fix error

> ./bin/omarchy-iso-make: ligne 46: omarchy-iso-boot: commande introuvable