### PR TITLE
Preserve firmware with reuse + use local pacman cache if you have it

### DIFF
--- a/bin/omarchy-iso-boot
+++ b/bin/omarchy-iso-boot
@@ -14,9 +14,8 @@ fi
 DISK="/tmp/omarchy-iso-boot.qcow2"
 if [[ ! -f $DISK || $2 != "reuse" ]]; then
   qemu-img create -f qcow2 "$DISK" 20G
+  cp /usr/share/edk2/x64/OVMF_VARS.4m.fd /tmp/OVMF_VARS.4m.fd
 fi
-
-cp /usr/share/edk2/x64/OVMF_VARS.4m.fd /tmp/OVMF_VARS.4m.fd
 
 # Boot from ISO before we've installed, then boot from drive after
 qemu-system-x86_64 \

--- a/bin/omarchy-iso-make
+++ b/bin/omarchy-iso-make
@@ -19,19 +19,27 @@ OMARCHY_INSTALLER_REPO="${OMARCHY_INSTALLER_REPO:-basecamp/omarchy}"
 OMARCHY_INSTALLER_REF="${OMARCHY_INSTALLER_REF:-master}"
 OMARCHY_INSTALLER_URL="${OMARCHY_INSTALLER_URL:-https://omarchy.org/install}"
 
-# Run the builder
-docker run --rm \
-  --privileged \
-  -e "OMARCHY_CONFIGURATOR_REPO=$OMARCHY_CONFIGURATOR_REPO" \
-  -e "OMARCHY_CONFIGURATOR_REF=$OMARCHY_CONFIGURATOR_REF" \
-  -e "OMARCHY_INSTALLER_REPO=$OMARCHY_INSTALLER_REPO" \
-  -e "OMARCHY_INSTALLER_REF=$OMARCHY_INSTALLER_REF" \
-  -e "OMARCHY_INSTALLER_URL=$OMARCHY_INSTALLER_URL" \
-  -v "$BUILD_RELEASE_PATH/:/out/" \
-  -v "$BUILD_ROOT/$BUILD_SCRIPT:/$BUILD_SCRIPT:ro" \
-  -v "$BUILD_ROOT/archiso:/archiso:ro" \
-  -v "$BUILD_ROOT/builder:/builder:ro" \
-  archlinux/archlinux:latest /$BUILD_SCRIPT
+DOCKER_ARGS=(
+  --rm
+  --privileged
+  -e "OMARCHY_CONFIGURATOR_REPO=$OMARCHY_CONFIGURATOR_REPO"
+  -e "OMARCHY_CONFIGURATOR_REF=$OMARCHY_CONFIGURATOR_REF"
+  -e "OMARCHY_INSTALLER_REPO=$OMARCHY_INSTALLER_REPO"
+  -e "OMARCHY_INSTALLER_REF=$OMARCHY_INSTALLER_REF"
+  -e "OMARCHY_INSTALLER_URL=$OMARCHY_INSTALLER_URL"
+  -v "$BUILD_RELEASE_PATH/:/out/"
+  -v "$BUILD_ROOT/$BUILD_SCRIPT:/$BUILD_SCRIPT:ro"
+  -v "$BUILD_ROOT/archiso:/archiso:ro"
+  -v "$BUILD_ROOT/builder:/builder:ro"
+)
+
+# Use local pacman cache if you already have one on host to speed up repeat runs
+if [ -d "/var/cache/pacman/pkg" ]; then
+  DOCKER_ARGS+=(-v "/var/cache/pacman/pkg:/var/cache/pacman/pkg")
+fi
+
+# Run the builder with assembled args
+docker run "${DOCKER_ARGS[@]}" archlinux/archlinux:latest /$BUILD_SCRIPT
 
 # Make iso accessible to all
 sudo chmod 777 -R "$BUILD_RELEASE_PATH"

--- a/bin/omarchy-iso-make-dev
+++ b/bin/omarchy-iso-make-dev
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+OMARCHY_INSTALLER_REF=dev \
+  OMARCHY_INSTALL_URL=https://omarchy.org/install-dev \
+  omarchy-iso-make --no-boot-offer

--- a/bin/omarchy-iso-make-dev
+++ b/bin/omarchy-iso-make-dev
@@ -2,4 +2,4 @@
 
 OMARCHY_INSTALLER_REF=dev \
   OMARCHY_INSTALL_URL=https://omarchy.org/install-dev \
-  omarchy-iso-make --no-boot-offer
+  omarchy-iso-make

--- a/bin/omarchy-iso-release
+++ b/bin/omarchy-iso-release
@@ -8,7 +8,7 @@ if [[ $1 != "--no-make" ]]; then
   echo -e "\e[32mMaking master ISO\e[0m"
   OMARCHY_INSTALLER_REF=master omarchy-iso-make --no-boot-offer
   echo -e "\e[32m\nMaking dev ISO\e[0m"
-  OMARCHY_INSTALLER_REF=dev omarchy-iso-make --no-boot-offer
+  OMARCHY_INSTALLER_REF=dev OMARCHY_INSTALL_URL=https://omarchy.org/install-dev omarchy-iso-make --no-boot-offer
 else
   echo -e "\e[31mSkipping remaking ISOs\e[0m"
 fi


### PR DESCRIPTION
Keeps the firmware if `reuse` is set to allow rebooting a VM without wiping EFI configs as well as mounts your local pacman cache if it exists to allow for faster builds overall when running locally.