### PR TITLE
fix: iso setup failing when password starts with dash(-)

### DIFF
--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -73,7 +73,7 @@ user_form() {
   done
 
   # Hash the password using yescrypt
-  password_hash=$(openssl passwd -6 "$password")
+  password_hash=$(printf '%s' "$password" | openssl passwd -6 -stdin)
 
   full_name=$(gum input --placeholder "Used for git authentication (hit return to skip)" --prompt.foreground="#845DF9" --prompt "Full name> ")
   email_address=$(gum input --placeholder "Used for git authentication (hit return to skip)" --prompt.foreground="#845DF9" --prompt "Email address> ")


### PR DESCRIPTION
## Description

The ISO setup previously failed when the password began with a dash (-), as `openssl passwd -6 "$password"` treated it as an option. This update ensures the password is correctly parsed and handled.

Addresses: [#2477](https://github.com/basecamp/omarchy/issues/2477)

### Before
Setup shows an error and fails:
https://github.com/user-attachments/assets/b724eb1c-7fe2-4e49-9ce7-cba48fb0cfa3


### After
Setup completes successfully without errors:
https://github.com/user-attachments/assets/4162505a-606c-4916-876e-04fce8b58d15

This can be verified directly in the terminal, since the same openssl command runs during setup.

### Before:
<img width="744" height="368" alt="screenshot-2025-10-19_10-55-03" src="https://github.com/user-attachments/assets/1ffd0aa2-4521-44e6-941b-310df656a0a9" />

### After:
<img width="1002" height="282" alt="screenshot-2025-10-19_10-55-34" src="https://github.com/user-attachments/assets/17d0fa3a-2fd0-4f53-aa55-26e1ea76c198" />
