### PR TITLE
README: Add /bin to path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,28 @@
 
 The Omarchy ISO streamlines [the installation of Omarchy](https://learn.omacom.io/2/the-omarchy-manual/50/getting-started). It includes the Omarchy Configurator as a front-end to archinstall and automatically launches the [Omarchy Installer](https://github.com/basecamp/omarchy) after base arch has been setup.
 
+## Setup
+
+Add the bin folder to your PATH to use the Omarchy ISO tools:
+
+```bash
+# Temporary (current session only)
+export PATH="$PATH:$(pwd)/bin"
+
+# Permanent (add to your ~/.bashrc or ~/.zshrc)
+echo 'export PATH="$PATH:'$(pwd)'/bin"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+After adding to PATH, you can run commands directly: `omarchy-iso-make` instead of `./bin/omarchy-iso-make`
+
 ## Downloading the latest ISO
 
 See the ISO link on [omarchy.org](https://omarchy.org).
 
 ## Creating the ISO
 
-Run `./bin/omarchy-iso-make` and the output goes into `./release`.
+Run `omarchy-iso-make` and the output goes into `./release`.
 
 ### Environment Variables
 
@@ -17,23 +32,24 @@ You can customize the repositories used during the build process by passing in v
 - `OMARCHY_INSTALLER_REPO` - GitHub repository for the installer (default: `basecamp/omarchy`)
 - `OMARCHY_INSTALLER_REF` - Git ref (branch/tag) for the installer (default: `master`)
 
-Example usage:
+**Example usage:**
+
 ```bash
-OMARCHY_INSTALLER_REPO="myuser/omarchy-fork" OMARCHY_INSTALLER_REF="some-feature" ./bin/omarchy-iso-make
+OMARCHY_INSTALLER_REPO="myuser/omarchy-fork" OMARCHY_INSTALLER_REF="some-feature" omarchy-iso-make
 ```
 
 ## Testing the ISO
 
-Run `./bin/omarchy-iso-boot [release/omarchy.iso]`.
+Run `omarchy-iso-boot [release/omarchy.iso]`.
 
 ## Signing the ISO
 
-Run `./bin/omarchy-iso-sign [gpg-user] [release/omarchy.iso]`.
+Run `omarchy-iso-sign [gpg-user] [release/omarchy.iso]`.
 
 ## Uploading the ISO
 
-Run `./bin/omarchy-iso-upload [release/omarchy.iso]`. This requires you've configured rclone (use `rclone config`).
+Run `omarchy-iso-upload [release/omarchy.iso]`. This requires you've configured rclone (use `rclone config`).
 
 ## Full release of the ISO
 
-Run `./bin/omarchy-iso-release` to create, test, sign, and upload the ISO in one flow.
+Run `omarchy-iso-release` to create, test, sign, and upload the ISO in one flow.


### PR DESCRIPTION
Just a subtle readme change to add a setup section for adding `/bin` to the PATH, and calling commands directly.