### PR TITLE
Harden ingest of user-provided passphrase

### DIFF
--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -121,7 +121,7 @@ user_form() {
   done
 
   # Hash the password using yescrypt
-  password_hash=$(openssl passwd -6 "$password")
+  password_hash=$(openssl passwd -6 pass:"$password")
 
   full_name=$(gum input --placeholder "Used for git authentication (hit return to skip)" --prompt.foreground="#845DF9" --prompt "Full name> ")
   email_address=$(gum input --placeholder "Used for git authentication (hit return to skip)" --prompt.foreground="#845DF9" --prompt "Email address> ")


### PR DESCRIPTION
This protects a user-provided passphrase, e.g. ones starting with a dash like `-foopassword`, from failing to get hashed.

See https://github.com/omacom-io/omarchy-iso/issues/51.