### PR TITLE
Fix password hash and password itself broken again from commit `9e7841c`

### DIFF
--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -121,7 +121,7 @@ user_form() {
   done
 
   # Hash the password using yescrypt
-  password_hash=$(openssl passwd -6 "$password")
+  password_hash=$(echo -n "$password" | openssl passwd -6 -stdin)
 
   full_name=$(gum input --placeholder "Used for git authentication (hit return to skip)" --prompt.foreground="#845DF9" --prompt "Full name> ")
   email_address=$(gum input --placeholder "Used for git authentication (hit return to skip)" --prompt.foreground="#845DF9" --prompt "Email address> ")


### PR DESCRIPTION
Adding "pass:" in the configurator in the `openssl passwd` command break the password itself & just prepends "pass:" string in the password itself nothing else.

`openssl passwd` command does not support "pass:" thing in the command as per [manual page](https://man.archlinux.org/man/openssl-passwd.1ssl.en), using `-stdin` is the better approach.

This properly fixes basecamp/omarchy#2477

P.S. I tested both by building, installing and testing the iso.
