### PR TITLE
Add --lite flag for minimal package ISO

### DIFF
--- a/bin/omarchy-iso-make
+++ b/bin/omarchy-iso-make
@@ -5,6 +5,7 @@ set -e
 
 # Parse command line arguments
 NO_CACHE=""
+OMARCHY_EDITION="full"
 while [[ $# -gt 0 ]]; do
   case $1 in
   --no-cache)
@@ -27,9 +28,13 @@ while [[ $# -gt 0 ]]; do
     OMARCHY_MIRROR=edge
     shift
     ;;
+  --lite)
+    OMARCHY_EDITION="lite"
+    shift
+    ;;
   *)
     echo "Unknown option: $1"
-    echo "Usage: $0 [--no-cache] [--no-boot-offer] [--local-source] [--dev] [--edge]"
+    echo "Usage: $0 [--no-cache] [--no-boot-offer] [--local-source] [--dev] [--edge] [--lite]"
     exit 1
     ;;
   esac
@@ -54,6 +59,7 @@ DOCKER_ARGS=(
   -e "OMARCHY_INSTALLER_REPO=$OMARCHY_INSTALLER_REPO"
   -e "OMARCHY_INSTALLER_REF=$OMARCHY_INSTALLER_REF"
   -e "OMARCHY_MIRROR=$OMARCHY_MIRROR"
+  -e "OMARCHY_EDITION=$OMARCHY_EDITION"
   -e "HOST_UID=$(id -u)"
   -e "HOST_GID=$(id -g)"
   -v "$BUILD_RELEASE_PATH/:/out/"
@@ -65,6 +71,13 @@ DOCKER_ARGS=(
 
 # Use local source of Omarchy from $OMARCHY_PATH instead of git checkout
 if [[ -n "${LOCAL_SOURCE-}" ]]; then
+  # Default OMARCHY_PATH to sibling directory if not set
+  OMARCHY_PATH="${OMARCHY_PATH:-$(realpath "$BUILD_ROOT/../omarchy")}"
+  if [[ ! -d "$OMARCHY_PATH" ]]; then
+    echo "ERROR: OMARCHY_PATH=$OMARCHY_PATH does not exist"
+    echo "Set OMARCHY_PATH to the omarchy repo location or place it at ../omarchy"
+    exit 1
+  fi
   DOCKER_ARGS+=(-v "$OMARCHY_PATH:/omarchy:ro")
 fi
 
@@ -88,7 +101,11 @@ docker run "${DOCKER_ARGS[@]}" archlinux/archlinux:latest /$BUILD_SCRIPT
 
 # Move as install ref
 latest_iso=$(\ls -t "$BUILD_RELEASE_PATH"/*.iso | head -n1)
-iso_ref="${latest_iso%.*}-$OMARCHY_INSTALLER_REF.iso"
+if [[ "$OMARCHY_EDITION" == "lite" ]]; then
+  iso_ref="${latest_iso%.*}-$OMARCHY_INSTALLER_REF-lite.iso"
+else
+  iso_ref="${latest_iso%.*}-$OMARCHY_INSTALLER_REF.iso"
+fi
 mv -f "$latest_iso" "$iso_ref"
 
 # Offer to boot the new build

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -6,6 +6,7 @@ use_omarchy_helpers() {
   export OMARCHY_INSTALL="/root/omarchy/install"
   export OMARCHY_INSTALL_LOG_FILE="/var/log/omarchy-install.log"
   export OMARCHY_MIRROR="$(cat /root/omarchy_mirror)"
+  export OMARCHY_EDITION="$(cat /root/omarchy_edition 2>/dev/null || echo 'full')"
   source /root/omarchy/install/helpers/all.sh
 }
 
@@ -130,6 +131,7 @@ chroot_bash() {
     OMARCHY_USER_NAME="$(<user_full_name.txt)" \
     OMARCHY_USER_EMAIL="$(<user_email_address.txt)" \
     OMARCHY_MIRROR="$OMARCHY_MIRROR" \
+    OMARCHY_EDITION="$OMARCHY_EDITION" \
     USER="$OMARCHY_USER" \
     HOME="/home/$OMARCHY_USER" \
     /bin/bash "$@"


### PR DESCRIPTION
This PR goes togeather with https://github.com/basecamp/omarchy/pull/4361
it allows us to create bloat free iso and inroduces a concept of packs. Now you can have a lite iso, full iso, dev tools, or communication apps

ex:
./bin/omarchy-iso-make --lite --local-source 

or
./bin/omarchy-iso-make --lite --local-source +dev

Full ISO is unchanged.

- Add --lite flag to omarchy-iso-make
- Pass OMARCHY_EDITION to Docker and persist to ISO
- Select lite package lists (base-lite + other-lite) when edition=lite
- Export OMARCHY_EDITION to installer environment
- ISO filename includes -lite suffix for lite builds
- Default OMARCHY_PATH to ../omarchy when using --local-source

