### PR TITLE
Add Unattended Installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Create `ssh.json` with a JSON array of public keys:
 
 When `ssh.json` is present, the installer enables `sshd`, configures DHCP networking, and populates `~/.ssh/authorized_keys`.
 
+### Drive encryption
+
+The interactive installer enables LUKS disk encryption by default, but autoinstall configs should **not** include `disk_encryption` in `user_configuration.json`. Encrypted disks require a passphrase at every boot, which blocks unattended operation. If your `user_configuration.json` was generated from the interactive configurator, remove the `disk_encryption` section from `disk_config`.
+
 ### Proxmox example
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -22,6 +22,76 @@ Example usage:
 OMARCHY_INSTALLER_REPO="myuser/omarchy-fork" OMARCHY_INSTALLER_REF="some-feature" ./bin/omarchy-iso-make
 ```
 
+## Autoinstall
+
+Autoinstall skips the interactive configurator by reading config files from a cloud-init drive (`cidata`). This works with the standard Omarchy ISO — no rebuild needed.
+
+### How it works
+
+1. Create config files (same format the interactive configurator generates)
+2. Put them on a small drive labeled `cidata`
+3. Attach both the Omarchy ISO and the cidata drive to your VM
+4. Set boot order to disk first, ISO as fallback
+5. Boot — the installer finds the config, installs automatically, and reboots into the installed system
+
+### Config files
+
+| File | Required | Purpose |
+|------|----------|---------|
+| `user_configuration.json` | Yes | archinstall config (disk, hostname, timezone, keyboard, etc.) |
+| `user_credentials.json` | Yes | Username and password hash |
+| `user_full_name.txt` | Yes | Git full name |
+| `user_email_address.txt` | Yes | Git email |
+| `ssh.json` | No | JSON array of SSH public keys — triggers SSH and networking setup |
+
+### Creating a cidata drive
+
+```bash
+# Put your config files in a directory
+mkdir -p cidata
+cp user_configuration.json user_credentials.json ssh.json cidata/
+
+# Create the ISO
+genisoimage -output cidata.iso -volid cidata -joliet -rock cidata/
+```
+
+### Generating a password hash
+
+```bash
+openssl passwd -6 "yourpassword"
+```
+
+Use the output as the `enc_password` value in `user_credentials.json`.
+
+### SSH keys
+
+Create `ssh.json` with a JSON array of public keys:
+
+```json
+["ssh-ed25519 AAAA... user@host"]
+```
+
+When `ssh.json` is present, the installer enables `sshd`, configures DHCP networking, and populates `~/.ssh/authorized_keys`.
+
+### Proxmox example
+
+```bash
+# Create VM with disk-first boot order
+qm create 101 --name my-omarchy \
+  --bios ovmf --machine q35 --cpu host --cores 4 --memory 8192 \
+  --ostype l26 --scsihw virtio-scsi-single \
+  --efidisk0 local-lvm:0,efitype=4m,pre-enrolled-keys=0 \
+  --scsi0 local-lvm:40,discard=on,iothread=1 \
+  --net0 virtio,bridge=vmbr0 --vga virtio --serial0 socket \
+  --ide2 local:iso/omarchy.iso,media=cdrom \
+  --ide3 local:iso/cidata.iso,media=cdrom \
+  --boot order='scsi0;ide2'
+
+qm start 101
+```
+
+Empty disk falls through to the ISO on first boot. After install, the system boots from disk.
+
 ## Testing the ISO
 
 Run `./bin/omarchy-iso-boot [release/omarchy.iso]`.

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -173,6 +173,13 @@ load_cidata() {
   return 1
 }
 
+skip_reboot_prompt_if_unattended() {
+  is_autoinstall || return 0
+
+  local finished_sh="/mnt/home/$OMARCHY_USER/.local/share/omarchy/install/post-install/finished.sh"
+  sed -i 's/if gum confirm.*Reboot Now.*/if true; then/' "$finished_sh"
+}
+
 configure_install() {
   if load_cidata; then
     touch /root/autoinstall_detected
@@ -186,5 +193,6 @@ if [[ $(tty) == "/dev/tty1" ]]; then
   use_omarchy_helpers
   configure_install
   install_arch
+  skip_reboot_prompt_if_unattended
   install_omarchy
 fi

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -39,11 +39,6 @@ install_arch() {
 install_omarchy() {
   chroot_bash -lc "sudo pacman -S --noconfirm --needed gum" >/dev/null
   chroot_bash -lc "source /home/$OMARCHY_USER/.local/share/omarchy/install.sh || bash"
-
-  # Reboot if requested by installer
-  if [[ -f /mnt/var/tmp/omarchy-install-completed ]]; then
-    reboot
-  fi
 }
 
 # Set Tokyo Night color scheme for the terminal
@@ -251,4 +246,9 @@ if [[ $(tty) == "/dev/tty1" ]]; then
   setup_ssh_if_unattended
   install_omarchy
   allow_ssh_through_firewall_if_unattended
+
+  # Reboot if installer completed successfully
+  if [[ -f /mnt/var/tmp/omarchy-install-completed ]]; then
+    reboot
+  fi
 fi

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -222,11 +222,17 @@ allow_ssh_through_firewall_if_unattended() {
   arch-chroot /mnt bash -c "command -v ufw &>/dev/null && ufw allow ssh" || true
 }
 
-skip_reboot_prompt_if_unattended() {
+auto_confirm_reboot_if_unattended() {
   is_autoinstall || return 0
 
   local finished_sh="/mnt/home/$OMARCHY_USER/.local/share/omarchy/install/post-install/finished.sh"
   sed -i 's/if gum confirm.*Reboot Now.*/if true; then/' "$finished_sh"
+}
+
+reboot_if_completed() {
+  if [[ -f /mnt/var/tmp/omarchy-install-completed ]]; then
+    reboot
+  fi
 }
 
 configure_install() {
@@ -242,13 +248,9 @@ if [[ $(tty) == "/dev/tty1" ]]; then
   use_omarchy_helpers
   configure_install
   install_arch
-  skip_reboot_prompt_if_unattended
+  auto_confirm_reboot_if_unattended
   setup_ssh_if_unattended
   install_omarchy
   allow_ssh_through_firewall_if_unattended
-
-  # Reboot if installer completed successfully
-  if [[ -f /mnt/var/tmp/omarchy-install-completed ]]; then
-    reboot
-  fi
+  reboot_if_completed
 fi


### PR DESCRIPTION
In this PR, I add unattended installs. I want to use the ISO with Packer and ProxMox for disposable dev environments so I need the ability to spin up and and down Omarchy installs without manual interaction.

This is is a first pass from Claude. I haven't started testing it yet. I'm working on this between other tasks. Feel free to comment, but expect that I will change things. Like the commit description, etc.