### PR TITLE
Exclude install media from disk picker

### DIFF
--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -217,6 +217,9 @@ get_root_disk() {
 
   [[ -n $device ]] || return 1
 
+  # /run/archiso/bootmnt usually resolves to the boot partition, but the
+  # installer picker works with whole disks. Walk back to the parent disk so
+  # the install media itself never shows up as a wipe target.
   device=$(readlink -f "$device" 2>/dev/null || printf "%s\n" "$device")
 
   while true; do

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -211,12 +211,33 @@ get_disk_info() {
   echo "$display"
 }
 
+get_root_disk() {
+  local device="$1"
+  local parent
+
+  [[ -n $device ]] || return 1
+
+  device=$(readlink -f "$device" 2>/dev/null || printf "%s\n" "$device")
+
+  while true; do
+    parent=$(lsblk -no PKNAME "$device" 2>/dev/null | tail -n1)
+    [[ -n $parent ]] || break
+    device="/dev/$parent"
+  done
+
+  if [[ $(lsblk -dno TYPE "$device" 2>/dev/null) == "disk" ]]; then
+    printf "%s\n" "$device"
+  fi
+}
+
 disk_form() {
   step "Let's select where to install Omarchy..."
 
   # Don't offer the install media as an option (Arch ISO mounts it here)
+  local boot_source
   local exclude_disk
-  exclude_disk=$(findmnt -no SOURCE /run/archiso/bootmnt 2>/dev/null || true)
+  boot_source=$(findmnt -no SOURCE /run/archiso/bootmnt 2>/dev/null || true)
+  exclude_disk=$(get_root_disk "$boot_source")
 
   # List all installable disks, excluding the boot device if present
   local available_disks


### PR DESCRIPTION
## Summary

Exclude the live install media from the Omarchy ISO disk picker.

Closes basecamp/omarchy#5167

The configurator was trying to hide the boot device by reading the mount source
for `/run/archiso/bootmnt`, but that source is usually a partition like
`/dev/sda1` while the installer presents whole disks like `/dev/sda`.

That mismatch let the USB installer disk stay in the list, where it could be
selected and wiped by mistake.

## What changed

- add `get_root_disk()` to walk a device back to its parent disk
- resolve `/run/archiso/bootmnt` to the root disk before filtering candidates
- document why the partition-to-disk normalization is required

## Verification

- `bash -n configs/airootfs/root/configurator`
- mocked `lsblk` checks confirming `/dev/sda1 -> /dev/sda`
- mocked disk list check confirming the resolved boot disk is excluded
