### PR TITLE
Disable xe Panel Replay on live boot for Panther Lake compatibility

### DIFF
--- a/configs/efiboot/loader/entries/01-archiso-x86_64-linux.conf
+++ b/configs/efiboot/loader/entries/01-archiso-x86_64-linux.conf
@@ -2,4 +2,4 @@ title    Omarchy (x86_64, UEFI)
 sort-key 01
 linux    /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-t2
 initrd   /%INSTALL_DIR%/boot/x86_64/initramfs-linux-t2.img
-options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet splash
+options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet splash xe.enable_panel_replay=0

--- a/configs/grub/grub.cfg
+++ b/configs/grub/grub.cfg
@@ -54,13 +54,13 @@ timeout_style=hidden
 
 menuentry "Omarchy (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet splash
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet splash xe.enable_panel_replay=0
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img
 }
 
 menuentry "Omarchy with speakup screen reader (%ARCH%, ${archiso_platform})" --hotkey s --class arch --class gnu-linux --class gnu --class os --id 'archlinux-accessibility' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on xe.enable_panel_replay=0
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img
 }
 

--- a/configs/grub/loopback.cfg
+++ b/configs/grub/loopback.cfg
@@ -30,13 +30,13 @@ timeout_style=hidden
 
 menuentry "Omarchy (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" quiet splash
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" quiet splash xe.enable_panel_replay=0
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img
 }
 
 menuentry "Omarchy with speakup screen reader (%ARCH%, ${archiso_platform})" --hotkey s --class arch --class gnu-linux --class gnu --class os --id 'archlinux-accessibility' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" accessibility=on
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" accessibility=on xe.enable_panel_replay=0
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img
 }
 

--- a/configs/syslinux/archiso_sys-linux.cfg
+++ b/configs/syslinux/archiso_sys-linux.cfg
@@ -6,7 +6,7 @@ ENDTEXT
 MENU LABEL Omarchy install medium (x86_64, BIOS)
 LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-t2
 INITRD /%INSTALL_DIR%/boot/x86_64/initramfs-linux-t2.img
-APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet splash
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet splash xe.enable_panel_replay=0
 
 # Accessibility boot option
 LABEL arch64speech
@@ -17,4 +17,4 @@ ENDTEXT
 MENU LABEL Omarchy install medium (x86_64, BIOS) with ^speech
 LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-t2
 INITRD /%INSTALL_DIR%/boot/x86_64/initramfs-linux-t2.img
-APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on xe.enable_panel_replay=0


### PR DESCRIPTION
Fixes the live installer freezing on ASUS ExpertBook B9406CAA (and likely other Panther Lake laptops where the eDP panel has a broken Panel Replay exit/wake path). Symptom: one frame draws, then the display stays frozen until a VT switch forces a full modeset. You can't see the installer TUI to complete an install.

Panel Replay is Xe3-new, default-on in the xe driver. The Dell XPS on Panther Lake had a similar issue earlier that was resolved upstream (see basecamp/omarchy migration 1776781956.sh); the B9406CAA panel still needs the arg disabled.

The fix (`xe.enable_panel_replay=0`) is applied universally on the live ISO boot because bootloaders can't DMI-match before the kernel loads. It's harmless on machines that don't need it:

- Non-Panther-Lake hardware: the xe driver either isn't loaded or Panel Replay isn't supported on that GPU; the arg is a no-op.
- Panther Lake machines with working Panel Replay: they only lose a power-saving feature during the ~15 minute install

Companion hardware-match fix for the installed system (scoped narrowly to B9406 via DMI) is basecamp/omarchy#5435. Full diagnostic writeup and context: basecamp/omarchy#5423.

AI Disclaimer: Fixes found with help from Claude Code (Opus 4.7).