### PR TITLE
Prefetch offline packages during wizard; boost CPU governor/C-states for install

### DIFF
--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -58,7 +58,19 @@ if [[ ${OMARCHY_INSTALL_DEBUG:-} == "1" ]]; then
 fi
 
 cd /root
+
+# Overlap USB/squashfs reads with wizard think-time: warm offline .pkg.tar.zst
+# files into the page cache at idle I/O priority before pacstrap begins.
+if command -v omarchy-offline-mirror-prefetch >/dev/null; then
+  omarchy-offline-mirror-prefetch start || true
+fi
+
 ./configurator
+
+# Stop prefetch before disk wipe / pacstrap so it cannot contend with install I/O.
+if command -v omarchy-offline-mirror-prefetch >/dev/null; then
+  omarchy-offline-mirror-prefetch stop || true
+fi
 
 # The foreground dashboard is now the sole visible install UI owner. It starts
 # the actual installer as a non-interactive child, logs child output, waits for

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -70,6 +70,9 @@ fi
 # Stop prefetch before disk wipe / pacstrap so it cannot contend with install I/O.
 if command -v omarchy-offline-mirror-prefetch >/dev/null; then
   omarchy-offline-mirror-prefetch stop || true
+  if [[ -f /run/omarchy-offline-prefetch.status ]]; then
+    echo "offline-mirror-prefetch: $(cat /run/omarchy-offline-prefetch.status)"
+  fi
 fi
 
 # The foreground dashboard is now the sole visible install UI owner. It starts

--- a/configs/airootfs/usr/local/bin/omarchy-offline-mirror-prefetch
+++ b/configs/airootfs/usr/local/bin/omarchy-offline-mirror-prefetch
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# Warm the offline package mirror into the page cache while the install
+# wizard runs, so pacstrap hits RAM instead of waiting on USB/squashfs.
+#
+# Usage:
+#   omarchy-offline-mirror-prefetch start
+#   omarchy-offline-mirror-prefetch stop
+#
+# Tunables (env):
+#   OMARCHY_OFFLINE_MIRROR          mirror dir (default below)
+#   OMARCHY_PREFETCH_RESERVE_MIB    RAM to leave free (default 2048)
+
+set -euo pipefail
+
+MIRROR="${OMARCHY_OFFLINE_MIRROR:-/var/cache/omarchy/mirror/offline}"
+PIDFILE=/run/omarchy-offline-prefetch.pid
+STATUS=/run/omarchy-offline-prefetch.status
+RESERVE_MIB="${OMARCHY_PREFETCH_RESERVE_MIB:-2048}"
+SELF=/usr/local/bin/omarchy-offline-mirror-prefetch
+
+# Packages installed before / alongside omarchy-base.packages. Keep in sync with
+# builder/archinstall.packages and orchestrator EARLY_* lists.
+PRIORITY_PACKAGES=(
+  base
+  linux
+  linux-firmware
+  amd-ucode
+  intel-ucode
+  mkinitcpio
+  btrfs-progs
+  base-devel
+  git
+  limine
+  efibootmgr
+  omarchy-keyring
+  openssh
+  pipewire
+  snapper
+  sof-firmware
+  alsa-firmware
+  lua51
+  luarocks
+)
+
+log_status() {
+  printf '%s\n' "$*" >"$STATUS"
+}
+
+mem_available_kib() {
+  awk '/^MemAvailable:/ { print $2; exit }' /proc/meminfo
+}
+
+resolve_pkg() {
+  local name=$1 path
+  # Prefer exact latest match for "name-version-release.pkg.tar.zst".
+  path=$(compgen -G "$MIRROR/$name-*.pkg.tar.zst" | sort -V | tail -n1 || true)
+  [[ -n $path && -f $path ]] || return 1
+  printf '%s\n' "$path"
+}
+
+# Emit offline .pkg.tar.zst paths: priority names + omarchy-base.packages first,
+# then remaining archives largest-first.
+list_prefetch_targets() {
+  local -A seen=()
+  local name path list
+
+  for name in "${PRIORITY_PACKAGES[@]}"; do
+    path=$(resolve_pkg "$name" || true)
+    [[ -n ${path:-} ]] || continue
+    [[ ${seen[$path]+x} ]] && continue
+    seen[$path]=1
+    printf '%s\n' "$path"
+  done
+
+  for list in /usr/share/omarchy-iso/omarchy-base.packages; do
+    [[ -f $list ]] || continue
+    while read -r name; do
+      [[ -z $name || $name == \#* ]] && continue
+      path=$(resolve_pkg "$name" || true)
+      [[ -n ${path:-} ]] || continue
+      [[ ${seen[$path]+x} ]] && continue
+      seen[$path]=1
+      printf '%s\n' "$path"
+    done <"$list"
+  done
+
+  while read -r path; do
+    [[ ${seen[$path]+x} ]] && continue
+    seen[$path]=1
+    printf '%s\n' "$path"
+  done < <(ls -1S "$MIRROR"/*.pkg.tar.zst 2>/dev/null || true)
+}
+
+warm_file() {
+  # Sequential read into page cache (no DONTNEED / O_DIRECT).
+  dd if="$1" of=/dev/null bs=1M status=none 2>/dev/null || true
+}
+
+prefetch_worker() {
+  renice -n 19 $$ >/dev/null 2>&1 || true
+  ionice -c 3 -p $$ >/dev/null 2>&1 || true
+
+  local budget_kib file size_kib loaded_kib=0 count=0
+  local avail_kib reserve_kib
+
+  avail_kib=$(mem_available_kib)
+  reserve_kib=$((RESERVE_MIB * 1024))
+  budget_kib=$((avail_kib - reserve_kib))
+  if ((budget_kib < 0)); then
+    budget_kib=0
+  fi
+
+  log_status "started avail_kib=$avail_kib budget_kib=$budget_kib reserve_mib=$RESERVE_MIB"
+
+  while read -r file; do
+    [[ -f $file ]] || continue
+    size_kib=$(du -k "$file" | awk '{ print $1 }')
+    if ((loaded_kib + size_kib > budget_kib)); then
+      log_status "budget_exhausted files=$count loaded_kib=$loaded_kib next=$(basename "$file") size_kib=$size_kib"
+      return 0
+    fi
+    warm_file "$file"
+    loaded_kib=$((loaded_kib + size_kib))
+    count=$((count + 1))
+    # Keep status fresh without flooding the filesystem every file on tiny pkgs.
+    if ((count % 5 == 0)); then
+      log_status "progress files=$count loaded_kib=$loaded_kib last=$(basename "$file")"
+    fi
+  done < <(list_prefetch_targets)
+
+  log_status "finished files=$count loaded_kib=$loaded_kib"
+}
+
+stop_prefetch() {
+  local pid child
+  [[ -f $PIDFILE ]] || return 0
+  pid=$(cat "$PIDFILE" 2>/dev/null || true)
+  rm -f "$PIDFILE"
+  [[ -n ${pid:-} ]] || return 0
+  if kill -0 "$pid" 2>/dev/null; then
+    # Stop any in-flight dd children, then the worker.
+    while read -r child; do
+      kill "$child" 2>/dev/null || true
+    done < <(ps -o pid= --ppid "$pid" 2>/dev/null || true)
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    log_status "stopped pid=$pid"
+  fi
+}
+
+start_prefetch() {
+  stop_prefetch
+
+  if [[ ! -d $MIRROR ]]; then
+    log_status "skipped missing_mirror=$MIRROR"
+    return 0
+  fi
+
+  if [[ ! -x $SELF ]]; then
+    SELF=$0
+  fi
+
+  "$SELF" _worker >/dev/null 2>&1 &
+  echo $! >"$PIDFILE"
+  disown $! 2>/dev/null || true
+  log_status "spawned pid=$(cat "$PIDFILE")"
+}
+
+case "${1:-}" in
+  start) start_prefetch ;;
+  stop) stop_prefetch ;;
+  _worker) prefetch_worker ;;
+  *)
+    echo "Usage: $0 {start|stop}" >&2
+    exit 2
+    ;;
+esac

--- a/configs/airootfs/usr/local/bin/omarchy-offline-mirror-prefetch
+++ b/configs/airootfs/usr/local/bin/omarchy-offline-mirror-prefetch
@@ -9,14 +9,17 @@
 #
 # Tunables (env):
 #   OMARCHY_OFFLINE_MIRROR          mirror dir (default below)
-#   OMARCHY_PREFETCH_RESERVE_MIB    RAM to leave free (default 2048)
+#   OMARCHY_PREFETCH_RESERVE_MIB    RAM to leave free (default: half of MemTotal)
+#   OMARCHY_PREFETCH_MAX_MIB        hard cap on bytes warmed (default 1536)
 
 set -euo pipefail
 
 MIRROR="${OMARCHY_OFFLINE_MIRROR:-/var/cache/omarchy/mirror/offline}"
 PIDFILE=/run/omarchy-offline-prefetch.pid
 STATUS=/run/omarchy-offline-prefetch.status
-RESERVE_MIB="${OMARCHY_PREFETCH_RESERVE_MIB:-2048}"
+# Keep install decompress/extract headroom. Over-filling page cache on 8G
+# machines made pacstrap *slower* under memory pressure.
+MAX_MIB="${OMARCHY_PREFETCH_MAX_MIB:-1536}"
 SELF=/usr/local/bin/omarchy-offline-mirror-prefetch
 
 # Packages installed before / alongside omarchy-base.packages. Keep in sync with
@@ -47,8 +50,29 @@ log_status() {
   printf '%s\n' "$*" >"$STATUS"
 }
 
-mem_available_kib() {
-  awk '/^MemAvailable:/ { print $2; exit }' /proc/meminfo
+mem_field_kib() {
+  awk -v key="$1" '$1 == key ":" { print $2; exit }' /proc/meminfo
+}
+
+prefetch_budget_kib() {
+  local avail_kib total_kib reserve_kib budget_kib max_kib
+  avail_kib=$(mem_field_kib MemAvailable)
+  total_kib=$(mem_field_kib MemTotal)
+  if [[ -n ${OMARCHY_PREFETCH_RESERVE_MIB:-} ]]; then
+    reserve_kib=$((OMARCHY_PREFETCH_RESERVE_MIB * 1024))
+  else
+    # Default: leave at least half of RAM for install extract/writeback.
+    reserve_kib=$((total_kib / 2))
+  fi
+  budget_kib=$((avail_kib - reserve_kib))
+  max_kib=$((MAX_MIB * 1024))
+  if ((budget_kib > max_kib)); then
+    budget_kib=$max_kib
+  fi
+  if ((budget_kib < 0)); then
+    budget_kib=0
+  fi
+  printf '%s %s %s' "$avail_kib" "$reserve_kib" "$budget_kib"
 }
 
 resolve_pkg() {
@@ -104,14 +128,9 @@ prefetch_worker() {
   local budget_kib file size_kib loaded_kib=0 count=0
   local avail_kib reserve_kib
 
-  avail_kib=$(mem_available_kib)
-  reserve_kib=$((RESERVE_MIB * 1024))
-  budget_kib=$((avail_kib - reserve_kib))
-  if ((budget_kib < 0)); then
-    budget_kib=0
-  fi
+  read -r avail_kib reserve_kib budget_kib <<<"$(prefetch_budget_kib)"
 
-  log_status "started avail_kib=$avail_kib budget_kib=$budget_kib reserve_mib=$RESERVE_MIB"
+  log_status "started avail_kib=$avail_kib reserve_kib=$reserve_kib budget_kib=$budget_kib max_mib=$MAX_MIB"
 
   while read -r file; do
     [[ -f $file ]] || continue

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -278,6 +278,92 @@ def _restore_cpu_governors(saved: dict[Path, str]) -> None:
         info(f"› CPU governor restored ({restored} CPUs)")
 
 
+def _cpuidle_disable_paths() -> list[Path]:
+    """Per-CPU cpuidle state disable knobs, excluding POLL (state0).
+
+    Deeper C-states (C1+) add wake latency when a core idles between extract
+    bursts. POLL is left alone — it is the zero-latency idle fallback.
+    """
+    base = Path("/sys/devices/system/cpu")
+    if not base.is_dir():
+        return []
+
+    paths: list[Path] = []
+    for cpu_dir in sorted(base.glob("cpu[0-9]*")):
+        cpuidle = cpu_dir / "cpuidle"
+        if not cpuidle.is_dir():
+            continue
+        for state_dir in sorted(cpuidle.glob("state[0-9]*")):
+            name_path = state_dir / "name"
+            disable_path = state_dir / "disable"
+            if not disable_path.is_file():
+                continue
+            try:
+                name = name_path.read_text().strip() if name_path.is_file() else ""
+            except OSError:
+                name = ""
+            if name == "POLL":
+                continue
+            paths.append(disable_path)
+    return paths
+
+
+def _read_cpuidle_disables() -> dict[Path, str]:
+    saved: dict[Path, str] = {}
+    for path in _cpuidle_disable_paths():
+        try:
+            saved[path] = path.read_text().strip()
+        except OSError:
+            continue
+    return saved
+
+
+def _write_cpuidle_disable(path: Path, value: str) -> bool:
+    try:
+        path.write_text(f"{value}\n")
+        return True
+    except OSError:
+        return False
+
+
+def _disable_cpuidle_cstates_for_install() -> dict[Path, str]:
+    """Disable deeper per-CPU idle C-states during package extract.
+
+    Orthogonal to the performance governor (P-states/frequency). No-op when
+    cpuidle sysfs is missing (some VMs). Returns prior disable values for
+    restore.
+    """
+    saved = _read_cpuidle_disables()
+    if not saved:
+        return {}
+
+    disabled = 0
+    for path in saved:
+        if _write_cpuidle_disable(path, "1"):
+            disabled += 1
+
+    if disabled:
+        # path: .../cpuN/cpuidle/stateM/disable
+        cpu_names = {path.parent.parent.parent.name for path in saved}
+        info(
+            f"› CPU idle C-states disabled ({len(cpu_names)} CPUs, {disabled} states) "
+            "for package install"
+        )
+    return saved
+
+
+def _restore_cpuidle_cstates(saved: dict[Path, str]) -> None:
+    if not saved:
+        return
+    restored = 0
+    for path, value in saved.items():
+        if value != "" and _write_cpuidle_disable(path, value):
+            restored += 1
+    if restored:
+        cpu_names = {path.parent.parent.parent.name for path in saved}
+        info(f"› CPU idle C-states restored ({len(cpu_names)} CPUs, {restored} states)")
+
+
 def arch_install_system(ctx: InstallContext) -> None:
     """Install the target system from the archinstall JSON.
 
@@ -317,6 +403,7 @@ def arch_install_system(ctx: InstallContext) -> None:
         _mount_offline_package_cache(ctx)
         _mask_mkinitcpio_pacman_hooks(ctx)
         prior_governors = _boost_cpu_governor_for_install()
+        prior_cpuidle = _disable_cpuidle_cstates_for_install()
         try:
             info("› installing base system (mkinitcpio deferred to final Limine UKI build)")
             installer.minimal_installation(
@@ -351,6 +438,7 @@ def arch_install_system(ctx: InstallContext) -> None:
             info("› installing Omarchy runtime + omarchy-base.packages")
             installer.add_additional_packages(_runtime_package_list(ctx))
         finally:
+            _restore_cpuidle_cstates(prior_cpuidle)
             _restore_cpu_governors(prior_governors)
             _unmask_mkinitcpio_pacman_hooks(ctx)
             _unmount_offline_package_cache(ctx)

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -216,6 +216,68 @@ def _stop_offline_mirror_prefetch() -> None:
     subprocess.run([str(prefetch), "stop"], check=False, capture_output=True)
 
 
+def _cpu_governor_paths() -> list[Path]:
+    base = Path("/sys/devices/system/cpu")
+    if not base.is_dir():
+        return []
+    return sorted(base.glob("cpu*/cpufreq/scaling_governor"))
+
+
+def _read_cpu_governors() -> dict[Path, str]:
+    saved: dict[Path, str] = {}
+    for path in _cpu_governor_paths():
+        try:
+            saved[path] = path.read_text().strip()
+        except OSError:
+            continue
+    return saved
+
+
+def _write_cpu_governor(path: Path, governor: str) -> bool:
+    try:
+        available = (path.parent / "scaling_available_governors").read_text().split()
+    except OSError:
+        available = []
+    if available and governor not in available:
+        return False
+    try:
+        path.write_text(f"{governor}\n")
+        return True
+    except OSError:
+        return False
+
+
+def _boost_cpu_governor_for_install() -> dict[Path, str]:
+    """Raise live CPUs to the performance governor during package extract.
+
+    No-op on hosts without cpufreq (common in VMs) or without a performance
+    governor. Returns the prior per-CPU governors for restore.
+    """
+    saved = _read_cpu_governors()
+    if not saved:
+        return {}
+
+    boosted = 0
+    for path in saved:
+        if _write_cpu_governor(path, "performance"):
+            boosted += 1
+
+    if boosted:
+        info(f"› CPU governor set to performance ({boosted} CPUs) for package install")
+    return saved
+
+
+def _restore_cpu_governors(saved: dict[Path, str]) -> None:
+    if not saved:
+        return
+    restored = 0
+    for path, governor in saved.items():
+        if governor and _write_cpu_governor(path, governor):
+            restored += 1
+    if restored:
+        info(f"› CPU governor restored ({restored} CPUs)")
+
+
 def arch_install_system(ctx: InstallContext) -> None:
     """Install the target system from the archinstall JSON.
 
@@ -254,6 +316,7 @@ def arch_install_system(ctx: InstallContext) -> None:
 
         _mount_offline_package_cache(ctx)
         _mask_mkinitcpio_pacman_hooks(ctx)
+        prior_governors = _boost_cpu_governor_for_install()
         try:
             info("› installing base system (mkinitcpio deferred to final Limine UKI build)")
             installer.minimal_installation(
@@ -288,6 +351,7 @@ def arch_install_system(ctx: InstallContext) -> None:
             info("› installing Omarchy runtime + omarchy-base.packages")
             installer.add_additional_packages(_runtime_package_list(ctx))
         finally:
+            _restore_cpu_governors(prior_governors)
             _unmask_mkinitcpio_pacman_hooks(ctx)
             _unmount_offline_package_cache(ctx)
 

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -208,6 +208,14 @@ def prepare_install_target(ctx: InstallContext) -> None:
         verify_protected_mounts(ctx)
 
 
+def _stop_offline_mirror_prefetch() -> None:
+    """Best-effort stop for the wizard-time page-cache warmer."""
+    prefetch = Path("/usr/local/bin/omarchy-offline-mirror-prefetch")
+    if not prefetch.exists():
+        return
+    subprocess.run([str(prefetch), "stop"], check=False, capture_output=True)
+
+
 def arch_install_system(ctx: InstallContext) -> None:
     """Install the target system from the archinstall JSON.
 
@@ -216,6 +224,8 @@ def arch_install_system(ctx: InstallContext) -> None:
     a pre-mounted target, and Omarchy derives boot/fstab details from that same
     input.
     """
+    _stop_offline_mirror_prefetch()
+
     handler = ctx.state["arch_config_handler"]
     mirror_handler = ctx.state["mirror_handler"]
     config = handler.config

--- a/configs/profiledef.sh
+++ b/configs/profiledef.sh
@@ -33,6 +33,7 @@ file_permissions=(
   ["/usr/local/bin/omarchy-iso-cleanup-disk"]="0:0:755"
   ["/usr/local/bin/omarchy-install-dashboard"]="0:0:755"
   ["/usr/local/bin/omarchy-iso-install"]="0:0:755"
+  ["/usr/local/bin/omarchy-offline-mirror-prefetch"]="0:0:755"
   ["/usr/local/bin/omarchy-upload-log"]="0:0:755"
   ["/var/cache/omarchy/mirror/offline/"]="0:0:775"
 )


### PR DESCRIPTION
## Summary
Install-speed changes for USB/live installs:

1. **Offline mirror page-cache prefetch** — overlap USB/squashfs package reads with configurator think-time by warming `/var/cache/omarchy/mirror/offline/*.pkg.tar.zst` into the Linux page cache before pacstrap.
2. **CPU governor boost** — raise live cpufreq governors to `performance` for the pacstrap/extract window when available, then restore prior governors in `finally` (no-op without cpufreq / `performance`).
3. **Disable deeper idle C-states** — for each CPU, disable `cpuidle` states except `POLL` for the same window, then restore (orthogonal to the governor; reduces wake latency between extract bursts).

### Prefetch details
- New `omarchy-offline-mirror-prefetch` helper (`start`/`stop`)
- Starts just before `./configurator`, stops when the wizard returns
- Hard-stop at the top of `arch_install_system`
- Idle priority (`nice 19` + `ionice idle`)
- Prefetch order: early/base priority packages → `omarchy-base.packages` → remaining largest-first
- RAM policy: leave ≥ half of `MemTotal` free, hard-cap warmed bytes at **1536 MiB** (`OMARCHY_PREFETCH_MAX_MIB`)

### CPU details
- Governor + C-state helpers in `phases_impl.py` around package install
- Logs when changed / restored
- Safe no-op on VMs or hosts without cpufreq/cpuidle

If you only want the CPU tweaks (no prefetch), see the split PR: https://github.com/omacom-io/omarchy-iso/pull/87 (governor + C-states only).

**Note for @dhh:** if you already have something similar in flight (or prefer a different approach), feel free to close/reject this — the research and real-USB measurement were still worth doing.

## Real hardware A/B (primary metric)

**Machine:** Razer Blade 15 — Intel Core i7-9750H (12) @ 4.50 GHz, 1 TB NVMe, 32 GiB RAM  
**Media:** USB stick flash of each ISO  
**Wizard:** felt fine with prefetch running (no UI issues)

| ISO | Install wall-clock |
|---|---:|
| Baseline Quattro (no prefetch / no CPU tweaks) | **5:36** |
| Candidate (prefetch + governor; local-source also included [omarchy#6404](https://github.com/basecamp/omarchy/pull/6404) updatedb deferral) | **4:31** |

**Δ ≈ −65 s (~19% faster).**

> Note: the candidate USB image was a local-source build, so the measured win includes the separate first-boot `updatedb` deferral from omarchy#6404 as well as this PR’s prefetch + governor changes. C-state disable was added after that measurement.

## Earlier QEMU results (for context; not the merge metric)

| Run | `Installing Arch + Omarchy` | phase sum |
|---|---:|---:|
| Baseline (no prefetch) | **55.26s** | 63.36s |
| Prefetch v1 (2 GiB reserve only) | 68.67s | 77.84s |
| Prefetch v1 retest | 63.89s | 72.56s |
| Prefetch v2 (½ RAM + 1.5 GiB cap) | 73.47s | 81.77s |

In the KVM / ISO-on-NVMe harness, prefetch alone **regressed** install time. Real USB media is the meaningful test — and that A/B improved.

## Test plan
- [x] Local ISO build with change
- [x] `omarchy-iso-test --install-only` vs prior ~55.3s baseline (QEMU; regression noted)
- [x] Real USB media A/B on Razer Blade 15 (5:36 → 4:31)
- [ ] Rebuild with C-state disable included; re-time on Blade 15
- [ ] Optional follow-up: isolate prefetch-only vs CPU-only vs updatedb-only on the same USB host
- [ ] Consider gating: only enable prefetch when boot media is removable, or require `OMARCHY_PREFETCH_FORCE=1`