### PR TITLE
Boot the T2 kernel the ISO says it boots

### DIFF
--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -116,6 +116,19 @@ cp "/tmp/$NODE_FILENAME" "$build_cache_dir/airootfs/opt/packages/"
 arch_packages=(linux-t2 git gum jq openssl plymouth python-terminaltexteffects tzupdate omarchy-keyring "$OMARCHY_SETTINGS_PACKAGE" lvm2 cryptsetup parted)
 printf '%s\n' "${arch_packages[@]}" >> "$build_cache_dir/packages.x86_64"
 
+# The live ISO boots linux-t2 (see airootfs/etc/mkinitcpio.d/linux-t2.preset), so
+# stock linux is a second kernel nobody boots: ~147MB of ISO, plus its own archiso
+# initramfs, copied into both the ISO tree and the size-constrained FAT EFI image.
+#
+# It cannot just be deleted — releng's broadcom-wl hard-depends on it, and it is
+# the only releng package that does, so pacman would drag the kernel straight back
+# in. broadcom-wl is a prebuilt module for stock linux and cannot load on the
+# kernel we boot, so it has done nothing since we started booting T2 anyway. The
+# install is entirely offline and the live environment needs no Wi-Fi driver.
+#
+# Anchored so linux-t2 and linux-firmware are untouched.
+sed -i -E '/^(linux|broadcom-wl)$/d' "$build_cache_dir/packages.x86_64"
+
 # Build the offline mirror: everything pacstrap might want during the target
 # install. With --local-source, the omarchy* packages we just built are
 # already in the mirror and we filter them out below. Without it, pacman -Syw

--- a/configs/airootfs/etc/mkinitcpio.d/linux-t2.preset
+++ b/configs/airootfs/etc/mkinitcpio.d/linux-t2.preset
@@ -1,0 +1,18 @@
+# mkinitcpio preset file for the 'linux-t2' package on archiso
+#
+# The filename is the pkgbase, and that is load-bearing. Kernel packages ship
+# nothing in /boot — they only install usr/lib/modules/<kver>/vmlinuz — so
+# mkinitcpio's alpm hook sources /etc/mkinitcpio.d/<pkgbase>.preset and copies
+# THAT package's kernel to whatever ALL_kver names (is_kernelcopy in
+# /usr/share/libalpm/scripts/mkinitcpio). Named linux.preset, this pointed the
+# stock kernel at the T2 filenames, so the ISO booted stock Arch while every
+# boot entry said linux-t2 and T2 Macs got no keyboard or trackpad.
+#
+# releng ships its own linux.preset for the stock kernel; leave it alone.
+
+PRESETS=('archiso')
+
+ALL_kver='/boot/vmlinuz-linux-t2'
+archiso_config='/etc/mkinitcpio.conf.d/archiso.conf'
+
+archiso_image="/boot/initramfs-linux-t2.img"

--- a/configs/airootfs/etc/mkinitcpio.d/linux.preset
+++ b/configs/airootfs/etc/mkinitcpio.d/linux.preset
@@ -1,9 +1,0 @@
-# mkinitcpio preset file for the 'linux' package on archiso
-
-PRESETS=('archiso')
-
-ALL_kver='/boot/vmlinuz-linux-t2'
-archiso_config='/etc/mkinitcpio.conf.d/archiso.conf'
-
-archiso_image="/boot/initramfs-linux-t2.img"
-

--- a/plans/aarch64-support.md
+++ b/plans/aarch64-support.md
@@ -76,9 +76,9 @@ aarch64 has no BIOS — only UEFI. Drop the syslinux path entirely on ARM.
 
 The cleanest cut: keep one `grub.cfg` shared, strip the x86 shell/memtest fragments at build time when `OMARCHY_ARCH=aarch64`. Don't fork the file.
 
-### 6. mkinitcpio preset — `configs/airootfs/etc/mkinitcpio.d/linux.preset`
+### 6. mkinitcpio preset — `configs/airootfs/etc/mkinitcpio.d/linux-t2.preset`
 
-References `vmlinuz-linux-t2` and `initramfs-linux-t2.img` (lines 5, 8). For aarch64, swap to `vmlinuz-linux` / `initramfs-linux.img`. Generate the file at build time from a template, keyed on arch.
+Names `vmlinuz-linux-t2` and `initramfs-linux-t2.img`. The filename is the pkgbase and the alpm hook keys off it, so aarch64 does not rename this file — it simply does not ship it, and releng's own `linux.preset` covers the stock kernel. Drop `linux-t2` from `arch_packages` on aarch64 and the boot entries point at `vmlinuz-linux` / `initramfs-linux.img`.
 
 ### 7. Configurator — `configs/airootfs/root/configurator`
 
@@ -145,7 +145,7 @@ Code:
 - `configs/efiboot/loader/loader.conf` — per-arch default entry
 - `configs/efiboot/loader/entries/01-archiso-x86_64-linux.conf` — generate aarch64 sibling at build time
 - `configs/grub/grub.cfg`, `loopback.cfg` — strip x86-only fragments on aarch64
-- `configs/airootfs/etc/mkinitcpio.d/linux.preset` — template by arch (drop linux-t2 on aarch64)
+- `configs/airootfs/etc/mkinitcpio.d/linux-t2.preset` — omit on aarch64 (drop linux-t2 there; releng's linux.preset covers the stock kernel)
 - `configs/airootfs/root/configurator` — branch archinstall JSON mirror list on `uname -m`; optionally guard lspci T2 probe
 - `.github/workflows/nightly-build.yml` — matrix x86_64/aarch64
 


### PR DESCRIPTION
## Scope, first

**This changes the live installer environment only. It does not change what any installed system runs.**

The live ISO boots **one kernel for every machine**. The installed system's kernel is chosen separately by `detect_kernel` in the configurator, which returns `linux-t2` only for Apple's T2 chip (`106b:1801`/`106b:1802`) and stock `linux` for everything else. That is unchanged here, and both packages remain in the offline mirror: `linux` via `builder/archinstall.packages`, `broadcom-wl` via omarchy's `omarchy-other.packages`, so `install/hardware/fix-bcm43xx.sh` can still install it offline on BCM4360/BCM4331 MacBooks after install.

## The bug

Every boot entry has named `vmlinuz-linux-t2` since [`0638855`](https://github.com/omacom-io/omarchy-iso/commit/0638855) (Sep 2025), but the file has contained stock Arch. Checked against a freshly built ISO:

```
arch/boot/x86_64/vmlinuz-linux-t2:
  Linux kernel x86 boot executable, bzImage, version 7.1.5-arch1-1 (linux@archlinux)
```

while the offline mirror carries `linux-t2-7.1.4-2`. **T2 MacBooks have been booting the installer with no keyboard or trackpad** — the hardware the T2 kernel was added for.

## Why

Kernel packages ship nothing in `/boot` — only `usr/lib/modules/<kver>/vmlinuz`. `install_kernel()` in `/usr/share/libalpm/scripts/mkinitcpio` sources `/etc/mkinitcpio.d/<pkgbase>.preset` and copies **that package's** kernel to whatever `ALL_kver` names, whenever `is_kernelcopy()` sees an unowned absolute path:

```bash
for kernel in "${kernellist[@]}"; do
    if is_kernelcopy "${kernel}"; then
        install -Dm644 -- "${line}" "${kernel}"
    fi
done
```

Our preset was named `linux.preset`, so it overrode releng's copy of the same name and pointed the **stock** kernel at the T2 filenames. `linux-t2`'s own generated preset writes those same two paths. They collide, and stock won.

The filename is the whole bug. [`c23e0e7`](https://github.com/omacom-io/omarchy-iso/commit/c23e0e7) introduced it one week after `0638855` added T2 support, so the feature worked for seven days and then silently stopped.

## The change

1. **Rename the preset to `linux-t2.preset`.** releng's `linux.preset` takes the stock kernel back, and the file the boot entries name finally gets the kernel it is named after.
2. **Drop stock `linux` and `broadcom-wl` from the live root.** Once linux-t2 actually boots, stock is a second kernel nobody boots — ~147MB, copied into both the ISO tree and the size-constrained FAT EFI image. It could not simply be deleted: `broadcom-wl` hard-depends on it and is the only releng package that does.

## Problems and trade-offs, stated plainly

- **The live kernel changes for 100% of installs**, not just T2 Macs — from stock 7.1.5 to T2-patched 7.1.4-2. That is the main risk here. The T2 kernel is stock plus patches and should boot everything, but "should" is doing real work in that sentence and nobody has confirmed it yet.
- **The live environment goes one point release behind** stock, and anything in the live root built against the running kernel now targets 7.1.4-t2.
- **`broadcom-wl` stops working in the live installer.** Being honest about the causality: it has kept working until now *because of this bug* — the ISO has been booting stock all along. It is a prebuilt module for stock linux and cannot load on linux-t2, so booting T2 is what takes it away; dropping the package only stops shipping something that can no longer load. The install is fully offline, so the live environment needs no Wi-Fi driver. `tzupdate`'s timezone geolocation will not work on those machines without Ethernet; the configurator already degrades gracefully.
- **Not verified on real T2 hardware.** The version string proves the right kernel now ships. It does not prove it boots, that the archiso hooks produce a working initramfs for it, or that the keyboard and trackpad come up.
- **A stray `linux.preset` from releng remains** in the live root for a package that is no longer installed. It is inert: the alpm hook only fires for installed kernel packages, and mkarchiso never runs `mkinitcpio -P`.

## Testing wanted

**Ordinary hardware matters most.** Every install now boots a different kernel than it did yesterday, so the common path carries the risk and the T2 case is the payoff. Please boot the ISO and run a full install on whatever you have — Intel, AMD, desktop, laptop, VM. Note **UEFI or BIOS**: both bootmodes name the same kernel files.

**T2 MacBook owners** are the case this exists for: confirm the built-in keyboard and trackpad work in the installer, then run a full install.

**Old Broadcom Macs** (pre-T2, BCM4360/BCM4331): confirm that losing `broadcom-wl` in the live environment does not block you, given the install is offline and the driver is still available on the installed system.

Please report machine, boot mode, and whether the install completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)