### PR TITLE
Boost CPU performance governor and disable deep C-states during install

### DIFF
--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -270,6 +270,92 @@ def _restore_cpu_governors(saved: dict[Path, str]) -> None:
         info(f"› CPU governor restored ({restored} CPUs)")
 
 
+def _cpuidle_disable_paths() -> list[Path]:
+    """Per-CPU cpuidle state disable knobs, excluding POLL (state0).
+
+    Deeper C-states (C1+) add wake latency when a core idles between extract
+    bursts. POLL is left alone — it is the zero-latency idle fallback.
+    """
+    base = Path("/sys/devices/system/cpu")
+    if not base.is_dir():
+        return []
+
+    paths: list[Path] = []
+    for cpu_dir in sorted(base.glob("cpu[0-9]*")):
+        cpuidle = cpu_dir / "cpuidle"
+        if not cpuidle.is_dir():
+            continue
+        for state_dir in sorted(cpuidle.glob("state[0-9]*")):
+            name_path = state_dir / "name"
+            disable_path = state_dir / "disable"
+            if not disable_path.is_file():
+                continue
+            try:
+                name = name_path.read_text().strip() if name_path.is_file() else ""
+            except OSError:
+                name = ""
+            if name == "POLL":
+                continue
+            paths.append(disable_path)
+    return paths
+
+
+def _read_cpuidle_disables() -> dict[Path, str]:
+    saved: dict[Path, str] = {}
+    for path in _cpuidle_disable_paths():
+        try:
+            saved[path] = path.read_text().strip()
+        except OSError:
+            continue
+    return saved
+
+
+def _write_cpuidle_disable(path: Path, value: str) -> bool:
+    try:
+        path.write_text(f"{value}\n")
+        return True
+    except OSError:
+        return False
+
+
+def _disable_cpuidle_cstates_for_install() -> dict[Path, str]:
+    """Disable deeper per-CPU idle C-states during package extract.
+
+    Orthogonal to the performance governor (P-states/frequency). No-op when
+    cpuidle sysfs is missing (some VMs). Returns prior disable values for
+    restore.
+    """
+    saved = _read_cpuidle_disables()
+    if not saved:
+        return {}
+
+    disabled = 0
+    for path in saved:
+        if _write_cpuidle_disable(path, "1"):
+            disabled += 1
+
+    if disabled:
+        # path: .../cpuN/cpuidle/stateM/disable
+        cpu_names = {path.parent.parent.parent.name for path in saved}
+        info(
+            f"› CPU idle C-states disabled ({len(cpu_names)} CPUs, {disabled} states) "
+            "for package install"
+        )
+    return saved
+
+
+def _restore_cpuidle_cstates(saved: dict[Path, str]) -> None:
+    if not saved:
+        return
+    restored = 0
+    for path, value in saved.items():
+        if value != "" and _write_cpuidle_disable(path, value):
+            restored += 1
+    if restored:
+        cpu_names = {path.parent.parent.parent.name for path in saved}
+        info(f"› CPU idle C-states restored ({len(cpu_names)} CPUs, {restored} states)")
+
+
 def arch_install_system(ctx: InstallContext) -> None:
     """Install the target system from the archinstall JSON.
 
@@ -307,6 +393,7 @@ def arch_install_system(ctx: InstallContext) -> None:
         _mount_offline_package_cache(ctx)
         _mask_mkinitcpio_pacman_hooks(ctx)
         prior_governors = _boost_cpu_governor_for_install()
+        prior_cpuidle = _disable_cpuidle_cstates_for_install()
         try:
             info("› installing base system (mkinitcpio deferred to final Limine UKI build)")
             installer.minimal_installation(
@@ -341,6 +428,7 @@ def arch_install_system(ctx: InstallContext) -> None:
             info("› installing Omarchy runtime + omarchy-base.packages")
             installer.add_additional_packages(_runtime_package_list(ctx))
         finally:
+            _restore_cpuidle_cstates(prior_cpuidle)
             _restore_cpu_governors(prior_governors)
             _unmask_mkinitcpio_pacman_hooks(ctx)
             _unmount_offline_package_cache(ctx)

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -208,6 +208,68 @@ def prepare_install_target(ctx: InstallContext) -> None:
         verify_protected_mounts(ctx)
 
 
+def _cpu_governor_paths() -> list[Path]:
+    base = Path("/sys/devices/system/cpu")
+    if not base.is_dir():
+        return []
+    return sorted(base.glob("cpu*/cpufreq/scaling_governor"))
+
+
+def _read_cpu_governors() -> dict[Path, str]:
+    saved: dict[Path, str] = {}
+    for path in _cpu_governor_paths():
+        try:
+            saved[path] = path.read_text().strip()
+        except OSError:
+            continue
+    return saved
+
+
+def _write_cpu_governor(path: Path, governor: str) -> bool:
+    try:
+        available = (path.parent / "scaling_available_governors").read_text().split()
+    except OSError:
+        available = []
+    if available and governor not in available:
+        return False
+    try:
+        path.write_text(f"{governor}\n")
+        return True
+    except OSError:
+        return False
+
+
+def _boost_cpu_governor_for_install() -> dict[Path, str]:
+    """Raise live CPUs to the performance governor during package extract.
+
+    No-op on hosts without cpufreq (common in VMs) or without a performance
+    governor. Returns the prior per-CPU governors for restore.
+    """
+    saved = _read_cpu_governors()
+    if not saved:
+        return {}
+
+    boosted = 0
+    for path in saved:
+        if _write_cpu_governor(path, "performance"):
+            boosted += 1
+
+    if boosted:
+        info(f"› CPU governor set to performance ({boosted} CPUs) for package install")
+    return saved
+
+
+def _restore_cpu_governors(saved: dict[Path, str]) -> None:
+    if not saved:
+        return
+    restored = 0
+    for path, governor in saved.items():
+        if governor and _write_cpu_governor(path, governor):
+            restored += 1
+    if restored:
+        info(f"› CPU governor restored ({restored} CPUs)")
+
+
 def arch_install_system(ctx: InstallContext) -> None:
     """Install the target system from the archinstall JSON.
 
@@ -244,6 +306,7 @@ def arch_install_system(ctx: InstallContext) -> None:
 
         _mount_offline_package_cache(ctx)
         _mask_mkinitcpio_pacman_hooks(ctx)
+        prior_governors = _boost_cpu_governor_for_install()
         try:
             info("› installing base system (mkinitcpio deferred to final Limine UKI build)")
             installer.minimal_installation(
@@ -278,6 +341,7 @@ def arch_install_system(ctx: InstallContext) -> None:
             info("› installing Omarchy runtime + omarchy-base.packages")
             installer.add_additional_packages(_runtime_package_list(ctx))
         finally:
+            _restore_cpu_governors(prior_governors)
             _unmask_mkinitcpio_pacman_hooks(ctx)
             _unmount_offline_package_cache(ctx)
 


### PR DESCRIPTION
## Summary
CPU-side install-speed tweaks only (no offline-mirror prefetch):

1. **Performance governor** — raise live cpufreq governors to `performance` for the pacstrap/extract window, then restore prior governors in `finally`.
2. **Disable deeper idle C-states** — for each CPU, set `cpuidle/state*/disable=1` except `POLL`, then restore prior values in `finally`.

These are orthogonal: governor controls P-states/frequency; C-state disable reduces wake latency when cores idle between extract/I/O bursts.

**Note for @dhh:** if you already have something similar (or prefer a different approach), feel free to close/reject — happy for this to land alone or not at all. The fuller experiment (prefetch + these tweaks) is in #85.

## Context
Related: #85 also includes offline mirror page-cache prefetch. This PR is the split so these two tweaks can be taken independently.

Real USB A/B on a Razer Blade 15 (i7-9750H, 1 TB NVMe, 32 GiB) with the *combined* candidate (prefetch + governor + [omarchy#6404](https://github.com/basecamp/omarchy/pull/6404) updatedb deferral) went **5:36 → 4:31**. This narrower PR does not claim that full delta by itself.

## Test plan
- [ ] Build ISO with these changes only
- [ ] Confirm install log shows governor + C-state disable/restore lines
- [ ] Optional: USB A/B vs baseline to isolate CPU-tweak contribution


Made with [Cursor](https://cursor.com)