### PR TITLE
Run the live CPUs at the performance governor during install

### DIFF
--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/main.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/main.py
@@ -65,10 +65,14 @@ def main() -> int:
     info(f"Installing Omarchy for {ctx.username} → {ctx.target}")
 
     from .phases_impl import (
+        boost_cpu_governor,
         cleanup_bind_mounts,
         cleanup_protected_state,
         cleanup_target_hook_masks,
+        restore_cpu_governors,
     )
+
+    governors = boost_cpu_governor()
 
     success = False
     try:
@@ -85,6 +89,7 @@ def main() -> int:
         info("Installation complete.")
         return 0
     finally:
+        restore_cpu_governors(governors)
         cleanup_bind_mounts(ctx)
         cleanup_target_hook_masks(ctx)
         if not success:

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -1396,6 +1396,40 @@ def _validate_pre_mounted_filesystems(ctx: InstallContext) -> None:
             raise RuntimeError(f"{crypttab} missing LUKS UUID {storage['luks_uuid']}")
 
 
+CPU_SYSFS = Path("/sys/devices/system/cpu")
+
+
+def boost_cpu_governor() -> dict[Path, str]:
+    """Run the live CPUs flat out for the install.
+
+    Package extraction and the UKI build are both CPU-bound, and archiso boots
+    on whatever governor the kernel defaults to. Writing an unsupported
+    governor just fails, so nothing needs probing first, and hosts without
+    cpufreq (most VMs) have no paths at all. Returns the prior governors.
+    """
+    saved: dict[Path, str] = {}
+    for path in sorted(CPU_SYSFS.glob("cpu*/cpufreq/scaling_governor")):
+        try:
+            saved[path] = path.read_text().strip()
+            path.write_text("performance\n")
+        except OSError:
+            saved.pop(path, None)
+
+    if saved:
+        info(f"› CPU governor set to performance ({len(saved)} CPUs)")
+    return saved
+
+
+def restore_cpu_governors(saved: dict[Path, str]) -> None:
+    """Only matters when an install fails and the user keeps using the live
+    environment — a successful one reboots out of it."""
+    for path, governor in saved.items():
+        try:
+            path.write_text(f"{governor}\n")
+        except OSError:
+            continue
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # cleanup_bind_mounts: invoked from main()'s finally so bind mounts get
 # unwound on success, failure, or interrupt. Idempotent.


### PR DESCRIPTION
Reduced from **#87 by @davydotcom** — the idea and the measurement work are his. He is credited as co-author on the commit. This lands the half I can justify without further data; see below for the half that still needs it.

## What it does

archiso boots on whatever governor the kernel defaults to, which on most laptops ramps conservatively. Package extraction and the UKI build are both CPU-bound, so pin `performance` for the install and put the prior governors back afterwards.

```python
saved: dict[Path, str] = {}
for path in sorted(CPU_SYSFS.glob("cpu*/cpufreq/scaling_governor")):
    try:
        saved[path] = path.read_text().strip()
        path.write_text("performance\n")
    except OSError:
        saved.pop(path, None)
```

Two functions in `phases_impl.py`, three lines of wiring in `main.py`. 39 lines total.

## Differences from #87

**No capability probing.** #87 read `scaling_available_governors` and compared before writing. Writing an unsupported governor returns `EINVAL`, which the `except OSError` already handles, so the check was a helper function earning nothing.

**Scoped to the whole install, not just the pacstrap window.** #87 wrapped `arch_install_system` only, which excludes `finalize_limine_boot` — mkinitcpio plus UKI compression, the most purely CPU-bound phase in the run. The boost now sits before the phase runner with the restore in the existing `finally`, so it covers every phase.

**The cpuidle C-state half is left out.** Rationale in #87.

## Tests

Seven cases against a fake sysfs tree:

| Case | Result |
|---|---|
| 8 CPUs on `schedutil` | all → `performance`, 8 saved |
| Restore | all → `schedutil` |
| Already on `performance` | boost and restore both no-op |
| No `cpufreq` at all (VM) | returns `{}`, no crash |
| `/sys` missing entirely | returns `{}` |
| One unwritable knob | boosts 3 of 4, no crash, count stays honest |
| Path vanished before restore | tolerated |

Also confirmed the glob matches real sysfs (16 paths for 16 CPUs on the dev machine), and that the boost runs before the `try` with the restore inside the `finally`.

## Honest limits

**The effect size is unmeasured and may be small.** With `intel_pstate` in active mode the only governors are `performance` and `powersave`, and `powersave` under HWP already ramps to max under sustained load — so on modern Intel the gain is mostly ramp-up, not steady state. The clearer win is on `acpi-cpufreq`/`schedutil` systems.

#87's 5:36 → 4:31 measured this bundled with a page-cache prefetch (already on `quattro` as 89245f4) and an updatedb deferral (basecamp/omarchy#6404), so none of that number is attributable to the governor alone.

The install log now shows `› CPU governor set to performance (N CPUs)`, which at least confirms it fired and on how many CPUs.

## Testing wanted

- A real install, watching for that line in the log.
- Ideally an A/B on an `acpi-cpufreq` or `schedutil` machine, where this should show the most.
- A VM run, to confirm the no-cpufreq path stays silent and harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)