### PR TITLE
Reject reserved usernames, bump the copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Anton Hvornum
+Copyright (c) 2026 Anton Hvornum
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -145,7 +145,11 @@ user_form() {
     username=$(gum input --placeholder "Alphanumeric without spaces (like dhh)" --prompt.foreground="#845DF9" --prompt "Username> ") || abort
 
     if [[ "$username" =~ ^[a-z_][a-z0-9_-]*[$]?$ ]]; then
-      break
+      if [[ "$username" =~ ^(root|bin|daemon|mail|ftp|http|nobody|dbus|systemd-coredump|systemd-network|systemd-oom|systemd-journal-remote|systemd-resolve|systemd-timesync|tss|uuidd|alpm|git|avahi|cups|lp|_talkd|polkitd|rtkit|qemu|brltty|gluster|rpc|libvirt-qemu|pcscd|nvidia-persistenced|sddm)$ ]] ; then
+        notice "Username is reserved for system" 1
+      else
+        break
+      fi
     else
       notice "Username must be alphanumeric with no spaces" 1
     fi


### PR DESCRIPTION
Two community fixes, applied to `quattro`. Both were opened against `main`, which is 143 commits behind and no longer the default branch, so merging them there would not have reached the shipping code. Both original authors are credited as co-authors on the commits.

**Reject reserved system usernames** — from #59 by @wolfgangw.

The configurator's regex accepted names that already exist on the target, so `useradd` failed inside `arch_install_system` — after the disk had been partitioned and formatted, which is the worst possible point to find out. The check applies cleanly to the current configurator.

**Update the copyright year** — from #61 by @LukaMarinkic. 2025 → 2026.

Verified: `bash -n` on the configurator, and the reserved-name branch sits inside the existing regex check so a valid non-reserved name still falls through to `break`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)