### PR TITLE
Fix the nightly ISO build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -2,40 +2,34 @@ name: Nightly ISO Build
 
 on:
   schedule:
-    - cron: '1 0 * * *'  # Daily at 00:01 UTC
-  workflow_dispatch:  # Allow manual triggering
+    - cron: "1 0 * * *" # Daily at 00:01 UTC
+  workflow_dispatch: # Allow manual triggering
 
 jobs:
   build-iso:
     runs-on: ubuntu-latest
-
-    container:
-      image: archlinux/archlinux:latest
-      options: --privileged
-    
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-      
-    - name: Build ISO in Arch Linux container
-      run: |
-        docker run --rm \
-          --privileged \
-          -v "${{ github.workspace }}:/workspace" \
-          -w /workspace \
-          archlinux:latest \
-          bash -c "
-            pacman -Syu --noconfirm && \
-            chmod +x build_iso.sh && \
-            ./build_iso.sh
-          "
-    
-    - name: Upload ISO artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: omarchy-iso-${{ github.run_number }}
-        path: out/*.iso
-        retention-days: 30
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+
+      - name: Build ISO
+        run: NO_BOOT_OFFER=1 ./bin/omarchy-iso-make
+
+      - name: Delete previously uploaded ISO artifact
+        uses: philips-labs/action-delete-artifacts@v1.0.0
+        with:
+          workflow: nightly-build.yml
+        continue-on-error: true
+
+      - name: Upload newly built ISO artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: omarchy-iso-${{ github.run_number }}
+          path: ./release/*.iso
+          retention-days: 1


### PR DESCRIPTION
The nightly workflow has been running `./build_iso.sh`, which has not existed for a long time — the build moved to `bin/omarchy-iso-make`. **Every scheduled run in the last 100 has failed**, going back to at least 2026-04-20.

Taken from #67 by @karthikkalidas, who is credited as co-author on the commit.

## Why not just merge #67

It was opened against `main`. The default branch is `quattro`, and scheduled workflows only run from the default branch — so merging it there would have left the nightly exactly as broken while looking fixed. It also carried 17 commits from a diverged fork. The workflow file is byte-identical on both branches, so the fix itself applies unchanged.

## What it does

- Runs `NO_BOOT_OFFER=1 ./bin/omarchy-iso-make` instead of the missing script. Verified that `iso-make` honours that variable — otherwise the job would hang on the interactive `gum confirm "Boot this ISO?"` at the end.
- Collects from `./release/*.iso`, where the ISO actually lands.
- Drops the outer `archlinux` container: `omarchy-iso-make` starts its own privileged container, so the job only needs Docker on the runner.
- Adds a disk-cleanup step. A ~6.5 GB ISO plus a ~4.5 GB offline mirror does not fit in a stock runner's free space.

## Worth watching on the first green run

- **Disk space.** Even after `free-disk-space`, the mirror plus the squashfs work directory plus the finished ISO is a lot for a hosted runner. This is the most likely remaining failure.
- **`philips-labs/action-delete-artifacts@v1.0.0`** is pinned by tag, not SHA. Worth pinning in a repo that builds ISOs.

YAML verified to parse; step list checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)