### PR TITLE
Add unattended installs via a cidata drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,63 @@ Despite the local folder name, the first argument is the Omarchy source checkout
 
 Use `--dev` or `--rc` to build against those package channels. Both `--dev` and `--edge` select the dev packages from the edge mirror.
 
+## Autoinstall
+
+The shipped ISO installs itself with no keyboard when it finds its configuration on a second drive. Attach a drive labeled `cidata` alongside the ISO and the installer copies the config off it and skips the configurator; with no such drive, nothing changes and the wizard runs as usual. No rebuild, no extra boot entry.
+
+`cidata` is the cloud-init `NoCloud` label, so Proxmox, libvirt, and Packer already know how to attach one.
+
+### Configuration files
+
+These are the configurator's own output files, so the way to get a starting set is to run one interactive install and copy what it wrote into `/root`.
+
+| File | Required | Purpose |
+|------|----------|---------|
+| `user_configuration.json` | Yes | archinstall config: disk, hostname, timezone, keyboard |
+| `user_credentials.json` | Yes | Username and password hash |
+| `user_full_name.txt` | No | Git full name |
+| `user_email_address.txt` | No | Git email |
+| `user_encrypt_installation.txt` | No | `true` to encrypt the install; defaults to false |
+| `ssh.json` | No | JSON array of SSH public keys |
+
+Both required files must be present or the installer falls back to the configurator. Generate the password hash for `user_credentials.json` with `openssl passwd -6 "yourpassword"`.
+
+`ssh.json` is a JSON array of public keys:
+
+```json
+["ssh-ed25519 AAAA... you@host"]
+```
+
+When `ssh.json` is present, autoinstall writes the keys to the user's `~/.ssh/authorized_keys`, enables `sshd`, and adds a `ufw allow ssh` rule — a stock Omarchy install ships openssh with the service disabled and its firewall opens neither port 22 nor anything else beyond LocalSend. Networking needs nothing extra; NetworkManager is already enabled with DHCP. Password SSH authentication is left at the distro default. An unparseable or empty `ssh.json` fails the install rather than producing a machine nobody can reach.
+
+### Building the drive
+
+```bash
+mkdir cidata
+cp user_configuration.json user_credentials.json ssh.json cidata/
+genisoimage -output cidata.iso -volid cidata -joliet -rock cidata/
+```
+
+### Proxmox example
+
+```bash
+qm create 101 --name my-omarchy \
+  --bios ovmf --machine q35 --cpu host --cores 4 --memory 8192 \
+  --ostype l26 --scsihw virtio-scsi-single \
+  --efidisk0 local-lvm:0,efitype=4m,pre-enrolled-keys=0 \
+  --scsi0 local-lvm:40,discard=on,iothread=1 \
+  --net0 virtio,bridge=vmbr0 --vga virtio --serial0 socket \
+  --ide2 local:iso/omarchy.iso,media=cdrom \
+  --ide3 local:iso/cidata.iso,media=cdrom \
+  --boot order='scsi0;ide2'
+
+qm start 101
+```
+
+Boot order is disk first: the empty disk falls through to the ISO on the first boot, and the installed system boots from disk afterwards. The machine reboots into Omarchy on its own when the install finishes.
+
+Encrypted autoinstalls are not fully unattended — the LUKS passphrase prompt still needs someone at the first boot.
+
 ## Testing the ISO
 
 Run `./bin/omarchy-iso-boot [release/omarchy.iso]`.

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -90,8 +90,45 @@ warm_offline_mirror &
 warm_pid=$!
 trap 'kill "$warm_pid" 2>/dev/null' EXIT
 
+# Autoinstall: a drive labeled cidata (the cloud-init NoCloud label, so Proxmox,
+# libvirt and Packer all know how to attach one) carrying the configurator's own
+# output stands in for the wizard. Copy those files into /root and everything
+# downstream runs the ordinary path against ordinary inputs.
+#
+# The required pair is the same one the orchestrator treats as mandatory; the
+# rest are optional there too, so don't be stricter here. Anything less than the
+# pair means this isn't an autoinstall drive, and we fall back to the wizard.
+load_cidata() {
+  local device="" label mnt=/run/cidata
+
+  for label in cidata CIDATA; do
+    [[ -e /dev/disk/by-label/$label ]] && { device=/dev/disk/by-label/$label; break; }
+  done
+  [[ -n $device ]] || return 1
+
+  mkdir -p "$mnt"
+  mount -o ro "$device" "$mnt" || return 1
+
+  if [[ -f $mnt/user_configuration.json && -f $mnt/user_credentials.json ]]; then
+    cp "$mnt"/user_configuration.json "$mnt"/user_credentials.json /root/
+    for file in user_full_name.txt user_email_address.txt user_encrypt_installation.txt ssh.json; do
+      [[ -f $mnt/$file ]] && cp "$mnt/$file" /root/
+    done
+    umount "$mnt"
+    return 0
+  fi
+
+  umount "$mnt"
+  return 1
+}
+
 cd /root
-./configurator
+if load_cidata; then
+  echo "Autoinstall configuration found on cidata drive; skipping the configurator."
+  export OMARCHY_UI_INTERACTIVE=no
+else
+  ./configurator
+fi
 
 # The foreground dashboard is now the sole visible install UI owner. It starts
 # the actual installer as a non-interactive child, logs child output, waits for
@@ -107,4 +144,5 @@ rm -f /run/omarchy-install/state.json
     --creds /root/user_credentials.json \
     --full-name-file /root/user_full_name.txt \
     --email-file /root/user_email_address.txt \
-    --encrypt-file /root/user_encrypt_installation.txt
+    --encrypt-file /root/user_encrypt_installation.txt \
+    --ssh-keys-file /root/ssh.json

--- a/configs/airootfs/usr/local/bin/omarchy-install-dashboard
+++ b/configs/airootfs/usr/local/bin/omarchy-install-dashboard
@@ -23,6 +23,12 @@ INSTALL_CMD=("$@")
 
 TTY_PATH="${OMARCHY_DASHBOARD_TTY:-/dev/tty}"
 LOGO_PATH="${OMARCHY_PATH:-/usr/share/omarchy}/logo.txt"
+
+# Autoinstall has no one at the keyboard, and every prompt this dashboard owns
+# reads from the TTY, so each would hang forever. Suppress them here rather than
+# in the scripts they live in: this process is the only owner of the visible UI.
+interactive() { [[ ${OMARCHY_UI_INTERACTIVE:-} != "no" ]]; }
+
 CSI=$'\033['
 RESET="${CSI}0m"
 DIM="${CSI}2m"
@@ -474,6 +480,10 @@ render_finish() {
 reboot_prompt() {
   local prompt_pad
 
+  # Nobody to confirm; the OMARCHY_UI_AUTO_REBOOT check at the call site still
+  # applies, so setting both stops on the finish screen without a keyboard.
+  interactive || return 0
+
   # Position the cursor one blank line below the title so the button sits right there.
   printf '%s%d;1H%s' "$CSI" "$((LOGO_HEIGHT + 5))" "$CLEAR_LINE" >"$TTY_PATH"
 
@@ -598,6 +608,9 @@ failure_menu() {
   local choice uploader
 
   [[ ${OMARCHY_UI_FAILURE_ACTION:-} == "exit" ]] && return 0
+  # The failure screen and log tail have already rendered; exit with the
+  # installer's status instead of blocking on a menu nobody can answer.
+  interactive || return 0
 
   while true; do
     uploader=""

--- a/configs/airootfs/usr/local/bin/omarchy-iso-install
+++ b/configs/airootfs/usr/local/bin/omarchy-iso-install
@@ -16,6 +16,7 @@ while [[ $# -gt 0 ]]; do
     --full-name-file)   export OMARCHY_INSTALL_FULL_NAME_FILE="$2"; shift 2 ;;
     --email-file)       export OMARCHY_INSTALL_EMAIL_FILE="$2"; shift 2 ;;
     --encrypt-file)     export OMARCHY_INSTALL_ENCRYPT_FILE="$2"; shift 2 ;;
+    --ssh-keys-file)    export OMARCHY_INSTALL_SSH_KEYS_FILE="$2"; shift 2 ;;
     *)                  echo "omarchy-iso-install: unknown arg $1" >&2; exit 2 ;;
   esac
 done

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/context.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/context.py
@@ -18,6 +18,7 @@ class InstallContext:
     full_name: str
     email: str
     encrypt: bool
+    ssh_keys_path: Path | None
 
     user_configuration: dict
     user_credentials: dict
@@ -59,6 +60,7 @@ class InstallContext:
             full_name=_read_text(os.environ.get("OMARCHY_INSTALL_FULL_NAME_FILE")),
             email=_read_text(os.environ.get("OMARCHY_INSTALL_EMAIL_FILE")),
             encrypt=_read_text(os.environ.get("OMARCHY_INSTALL_ENCRYPT_FILE")).lower() in ("true", "yes", "1"),
+            ssh_keys_path=_optional_path(os.environ.get("OMARCHY_INSTALL_SSH_KEYS_FILE")),
             user_configuration=user_configuration,
             user_credentials=json.loads(creds_path.read_text()),
             arch_config_path=arch_config_path,
@@ -101,6 +103,16 @@ def _default_omarchy_install(user_configuration: dict) -> dict[str, Any]:
         },
         "storage": {},
     }
+
+
+def _optional_path(path: str | None) -> Path | None:
+    """A path the caller always passes but that need not exist. The live ISO
+    passes --ssh-keys-file on every install; only autoinstall drives put a file
+    there."""
+    if not path:
+        return None
+    p = Path(path)
+    return p if p.exists() else None
 
 
 def _read_text(path: str | None) -> str:

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/main.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/main.py
@@ -38,6 +38,7 @@ def build_phases(ctx: InstallContext):
         run_chroot_finalizer,
         configure_dns_resolver,
         configure_login,
+        configure_ssh_access,
         validate_boot,
     )
 
@@ -50,6 +51,7 @@ def build_phases(ctx: InstallContext):
         ("Finalizing Limine boot",     finalize_limine_boot),
         ("Finalizing user",            run_chroot_finalizer),
         ("Configuring login",          configure_login),
+        ("Configuring SSH access",     configure_ssh_access),
         ("Configuring DNS resolver",   configure_dns_resolver),
         ("Validating boot setup",      validate_boot),
     ]

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -15,12 +15,14 @@ Phase ordering (full-disk and protected/pre-mounted):
     finalize_limine_boot   → final Limine config/UKI build after hardware drop-ins
     run_chroot_finalizer   → arch-chroot -u user omarchy-finalize-user
     configure_login        → sddm state + encrypted-install autologin
+    configure_ssh_access   → authorized_keys for autoinstall; no-op otherwise
     validate_boot          → assert UKI / limine.conf / kernel cmdline are sane
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
 import shutil
@@ -1284,6 +1286,93 @@ def configure_login(ctx: InstallContext) -> None:
         ["arch-chroot", str(ctx.target), "systemctl", "enable", "sddm.service"],
         check=False, capture_output=True,
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# configure_ssh_access: make the installed machine reachable over SSH with the
+# keys an autoinstall drive supplied. A stock Omarchy install ships openssh but
+# leaves sshd disabled, and its firewall.sh opens only LocalSend and docker DNS,
+# so all three pieces -- keys, service, firewall -- have to be done here.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def configure_ssh_access(ctx: InstallContext) -> None:
+    if ctx.ssh_keys_path is None:
+        return
+
+    keys = _authorized_keys(ctx.ssh_keys_path)
+    info(f"› installing {len(keys)} SSH key(s) for {ctx.username}")
+
+    ssh_dir = ctx.target / "home" / ctx.username / ".ssh"
+    ssh_dir.mkdir(parents=True, exist_ok=True)
+    ssh_dir.chmod(0o700)
+
+    authorized_keys = ssh_dir / "authorized_keys"
+    authorized_keys.write_text("".join(f"{key}\n" for key in keys))
+    authorized_keys.chmod(0o600)
+
+    # Ask the target for the uid rather than assuming the first user is 1000.
+    # Uncaptured so a failure shows up in the install log, and checked because
+    # a root-owned authorized_keys is one sshd refuses to read.
+    subprocess.run(
+        ["arch-chroot", str(ctx.target), "chown", "-R",
+         f"{ctx.username}:{ctx.username}", f"/home/{ctx.username}/.ssh"],
+        check=True,
+    )
+
+    info("› enabling sshd")
+    subprocess.run(
+        ["arch-chroot", str(ctx.target), "systemctl", "enable", "sshd.service"],
+        check=True,
+    )
+
+    _allow_ssh_through_firewall(ctx)
+
+
+def _allow_ssh_through_firewall(ctx: InstallContext) -> None:
+    """Open port 22 in the target's ufw.
+
+    Omarchy's install/config/firewall.sh opens LocalSend and docker DNS and
+    nothing else, and ufw runs default-deny incoming, so an enabled sshd is
+    still unreachable -- connections time out rather than being refused.
+
+    ufw cannot reach netfilter from inside the chroot and exits non-zero saying
+    so, but it writes the rule to user.rules first, and that file is what
+    ufw.service loads on first boot. So the exit status is the wrong thing to
+    check here; the rule landing in the file is the thing that matters.
+    """
+    if not (ctx.target / "usr" / "bin" / "ufw").exists():
+        info("› no ufw in target, leaving firewall alone")
+        return
+
+    info("› allowing SSH through ufw")
+    subprocess.run(["arch-chroot", str(ctx.target), "ufw", "allow", "ssh"], check=False)
+
+    rules = ctx.target / "etc" / "ufw" / "user.rules"
+    text = rules.read_text() if rules.exists() else ""
+    if "--dport 22 -j ACCEPT" not in text:
+        raise RuntimeError(f"ufw did not record an allow rule for port 22 in {rules}")
+
+
+def _authorized_keys(path: Path) -> list[str]:
+    """Parse the autoinstall ssh.json: a JSON array of public key strings.
+
+    Raise rather than skip on anything unusable. An install that "succeeds"
+    into a machine nobody can log into is worse than one that stops with the
+    reason on screen.
+    """
+    try:
+        keys = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{path} is not readable JSON: {exc}") from exc
+
+    if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
+        raise RuntimeError(f"{path} must be a JSON array of public key strings")
+
+    keys = [key.strip() for key in keys if key.strip()]
+    if not keys:
+        raise RuntimeError(f"{path} contains no SSH keys")
+
+    return keys
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/plans/autoinstall.md
+++ b/plans/autoinstall.md
@@ -26,12 +26,17 @@ This is Ryan Hughes' suggestion from PR #72 and it is what keeps the diff small:
 
 ### What the ISO already does for us
 
-Two things that would otherwise need building are already true on a stock quattro install, per `manifests/fresh-4-semantic.json`:
+One thing that would otherwise need building is already true on a stock install: `NetworkManager.service` is enabled and active with DHCP by default, so autoinstall needs no `systemd-networkd` unit — one would contend with NetworkManager.
 
-- `sshd.service` is enabled.
-- `NetworkManager.service` is enabled and active, with DHCP by default.
+Remote access needs three things, all verified against a real install rather than inferred:
 
-So remote access needs only an `authorized_keys` file. No `systemd-networkd` unit (it would contend with NetworkManager), no `systemctl enable sshd`, and specifically no loosening of `PasswordAuthentication` — key auth is the only thing autoinstall adds.
+- `authorized_keys` for the user.
+- `systemctl enable sshd.service`. Omarchy ships `openssh` but leaves the service disabled.
+- `ufw allow ssh`. `install/config/firewall.sh` opens LocalSend (53317) and docker DNS and nothing else, and ufw runs default-deny incoming.
+
+Still no loosening of `PasswordAuthentication` — key auth only.
+
+Do not take `manifests/fresh-4-semantic.json` as the authority on any of this. It claims `sshd.service: enabled` and carries an `allow tcp 22` ufw rule; a real install of this ISO has neither. It is a snapshot of one machine's state, not a contract about stock behavior, and trusting it cost two test cycles.
 
 ### Non-interactivity belongs to the dashboard
 
@@ -109,12 +114,14 @@ The dashboard is the only process that owns the visible UI. Suppressing its prom
 ### Changes
 - `omarchy-iso-install`: add `--ssh-keys-file` to the arg loop, exporting `OMARCHY_INSTALL_SSH_KEYS_FILE`. Same shape as the five existing flags, ahead of the `unknown arg` catch-all (`:19`).
 - `context.py`: add an `ssh_keys_path: Path | None` field populated from that variable in `from_env`, `None` when unset or when the file does not exist.
-- `phases_impl.py`: add `configure_remote_access(ctx)`:
+- `phases_impl.py`: add `configure_ssh_access(ctx)`:
   - Return immediately when `ctx.ssh_keys_path` is `None`.
   - Parse the file as a JSON array of public key strings; write them one per line to `<target>/home/<user>/.ssh/authorized_keys`.
   - `.ssh` at `0700`, `authorized_keys` at `0600`, both owned by the user via `arch-chroot <target> chown -R <user>:<user>`. Do not hardcode uid 1000 as PR #72 did — ask the target for it.
+  - `arch-chroot <target> systemctl enable sshd.service`. Works cleanly in the chroot.
+  - `arch-chroot <target> ufw allow ssh` when the target has ufw. This one exits **non-zero** in a chroot (`ERROR: problem running`) because ufw cannot reach netfilter, but it writes the rule to `/etc/ufw/user.rules` before failing, and that file is what `ufw.service` loads on first boot. So ignore the exit status and assert the rule landed in the file instead.
   - A malformed or empty `ssh.json` must fail the phase loudly. A machine that installs "successfully" and is then unreachable is worse than one that stops with an error on screen.
-- `main.py`: register `("Configuring remote access", configure_remote_access)` in `build_phases` after `configure_login` (`:52`) and before `validate_boot`.
+- `main.py`: register `("Configuring SSH access", configure_ssh_access)` in `build_phases` after `configure_login` (`:52`) and before `validate_boot`.
 
 ### Model to follow
 `configure_login` (`phases_impl.py:1251`) — direct writes against `ctx.target`, `arch-chroot` reserved for ownership and `systemctl`. Match its structure.
@@ -123,6 +130,7 @@ The dashboard is the only process that owns the visible UI. Suppressing its prom
 - Install with `ssh.json`: `ssh <user>@<vm>` works with the corresponding private key on first boot, no password.
 - Install without `ssh.json`: phase runs, does nothing, install unaffected; `~/.ssh` is not created.
 - `authorized_keys` is `0600` and owned by the install user, not root.
+- Port 22 is open in ufw on the installed system. Test this by connecting, not by reading the phase log — the rule is written from a chroot that cannot verify it.
 - Password SSH auth is left at the distro default — autoinstall does not enable it.
 - Interactive installs are unaffected: the flag is passed but the file never exists.
 
@@ -169,4 +177,4 @@ PR #72 targeted the pre-`quattro` tree and cannot be rebased: `use_omarchy_helpe
 - The `systemd-networkd` DHCP unit — unnecessary; NetworkManager is already enabled and would contend with it.
 - The `PasswordAuthentication yes` rewrite — unnecessary and a security downgrade.
 
-`load_cidata` is the one piece that carries over close to intact.
+`load_cidata` is the one piece that carries over close to intact. PR #72's `ufw allow ssh` also carries over: it was dropped from the first draft of this plan on the reasoning that an enabled sshd is a reachable sshd, and a test install proved otherwise. That PR was right to include it.

--- a/plans/autoinstall.md
+++ b/plans/autoinstall.md
@@ -1,0 +1,172 @@
+# Autoinstall Plan
+
+## Goal
+
+Let the standard Omarchy ISO install itself with no keyboard present, driven by config files handed to the VM on a second drive. This makes Omarchy usable as a Packer/Proxmox base image for disposable dev environments: create VM, boot, walk away, SSH in.
+
+## Product Requirements
+
+- No ISO rebuild. The shipped ISO autoinstalls when config is present and runs the configurator when it is not.
+- No new menu entry, no new boot parameter, no separate ISO flavor.
+- Config format is exactly what the configurator already writes — no second schema to maintain.
+- The installed machine is reachable over SSH with a key supplied at install time.
+- Interactive installs behave identically to today.
+
+---
+
+## Chosen Architecture
+
+### Trigger: config presence, not a mode flag
+
+The installer looks for a drive labeled `cidata` at startup. If it is there and carries the configurator's output files, those files are copied into `/root` and `./configurator` is skipped — the rest of the install runs the ordinary path against ordinary inputs. If it is not there, nothing changes.
+
+This is Ryan Hughes' suggestion from PR #72 and it is what keeps the diff small: the install pipeline can be rewritten freely as long as it keeps reading its five files out of `/root`, and autoinstall follows along for free.
+
+`cidata` is the cloud-init `NoCloud` label, so Proxmox, libvirt, and Packer all already know how to attach one.
+
+### What the ISO already does for us
+
+Two things that would otherwise need building are already true on a stock quattro install, per `manifests/fresh-4-semantic.json`:
+
+- `sshd.service` is enabled.
+- `NetworkManager.service` is enabled and active, with DHCP by default.
+
+So remote access needs only an `authorized_keys` file. No `systemd-networkd` unit (it would contend with NetworkManager), no `systemctl enable sshd`, and specifically no loosening of `PasswordAuthentication` — key auth is the only thing autoinstall adds.
+
+### Non-interactivity belongs to the dashboard
+
+`omarchy-install-dashboard` owns every prompt that survives to the end of an install: the reboot confirm and, on failure, the action menu. Both are `gum` calls reading from the TTY, and both hang forever on a headless VM. Autoinstall therefore sets one env var that the dashboard reads, rather than patching prompts out of scripts after the fact — which is what PR #72 did to `finished.sh`, and what everyone correctly disliked.
+
+---
+
+## Non-Goals
+
+- No config generator, validator, or schema doc. The configurator is the source of truth for the format; users copy its output.
+- No secret management. Whoever builds the `cidata` drive owns the password hash and the public key on it.
+- No PXE, no network-fetched config, no cloud-init compatibility beyond reusing the drive label.
+- No changes to disk selection, encryption, or any install phase behavior.
+
+---
+
+## Repo Implementation Plan
+
+## 1) Detect the cidata drive and skip the configurator
+
+### File
+- `configs/airootfs/root/.automated_script.sh`
+
+### Changes
+- Add a `load_cidata` function above the existing `cd /root` (`:93`):
+  - Look for `/dev/disk/by-label/cidata` then `/dev/disk/by-label/CIDATA`; return non-zero if neither exists.
+  - Mount read-only on a temp mountpoint; return non-zero if the mount fails.
+  - Require both `user_configuration.json` and `user_credentials.json` on the drive — this is the same pair `InstallContext.from_env` treats as mandatory. Missing either means the drive is not an autoinstall drive; unmount and return non-zero.
+  - Copy the required pair plus, when present, `user_full_name.txt`, `user_email_address.txt`, `user_encrypt_installation.txt`, and `ssh.json` into `/root`.
+  - Unmount before returning. Leave nothing mounted for the install to trip over.
+- Replace the bare `./configurator` call (`:94`) with: run `load_cidata`; on success export `OMARCHY_UI_INTERACTIVE=no`, on failure run `./configurator`.
+- Pass `--ssh-keys-file /root/ssh.json` to `omarchy-iso-install` in the dashboard invocation (`:101`–`:110`), alongside the existing five flags. Always pass it; the orchestrator no-ops when the file is absent, which keeps the interactive path on the identical command line.
+
+### Notes
+- The three text files are optional by construction: `_read_text` in `context.py` returns `""` for a missing path and `encrypt` falls back to false. Do not add stricter checks here than the orchestrator itself applies.
+- `load_cidata` must not run before `warm_offline_mirror` is backgrounded — the mirror warm should keep its head start.
+
+### Acceptance criteria
+- ISO with no `cidata` drive attached: configurator runs, byte-identical UX to today.
+- ISO with a `cidata` drive carrying the five files: configurator never appears; install starts within seconds of boot.
+- ISO with a drive labeled `cidata` that is empty or carries only one of the two required files: falls back to the configurator rather than failing the boot.
+- Nothing remains mounted from `/dev/disk/by-label/cidata` once the install begins.
+
+---
+
+## 2) Non-interactive dashboard
+
+### File
+- `configs/airootfs/usr/local/bin/omarchy-install-dashboard`
+
+### Changes
+- Read `OMARCHY_UI_INTERACTIVE` once near the other env reads at the top.
+- In `reboot_prompt()` (`:474`): when non-interactive, return 0 immediately instead of calling `gum confirm`. The existing `OMARCHY_UI_AUTO_REBOOT=no` check at `:737` stays in front of the actual `reboot`, so a debug run can set both and stop on the finish screen without a keyboard.
+- In `failure_menu()` (`:597`): treat non-interactive as equivalent to the existing `OMARCHY_UI_FAILURE_ACTION=exit` early return (`:600`), so a failed autoinstall exits with the installer's status instead of blocking on `gum choose` forever. The failure screen and log tail still render, and the serial console still captures them.
+
+### Why here and not in the caller
+The dashboard is the only process that owns the visible UI. Suppressing its prompts anywhere else means editing scripts it invokes — the `finished.sh` `sed` from PR #72 — which breaks the moment those scripts move.
+
+### Acceptance criteria
+- Autoinstall run reaches the finish screen and reboots with no input.
+- Autoinstall run whose install fails renders the failure screen, exits non-zero, and does not hang.
+- Interactive run still prompts for reboot and still offers the failure menu.
+- `OMARCHY_UI_INTERACTIVE=no` plus `OMARCHY_UI_AUTO_REBOOT=no` stops at the finish screen without prompting.
+
+---
+
+## 3) SSH keys as an orchestrator phase
+
+### Files
+- `configs/airootfs/usr/local/bin/omarchy-iso-install`
+- `configs/airootfs/usr/share/omarchy-iso/orchestrator/context.py`
+- `configs/airootfs/usr/share/omarchy-iso/orchestrator/main.py`
+- `configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py`
+
+### Changes
+- `omarchy-iso-install`: add `--ssh-keys-file` to the arg loop, exporting `OMARCHY_INSTALL_SSH_KEYS_FILE`. Same shape as the five existing flags, ahead of the `unknown arg` catch-all (`:19`).
+- `context.py`: add an `ssh_keys_path: Path | None` field populated from that variable in `from_env`, `None` when unset or when the file does not exist.
+- `phases_impl.py`: add `configure_remote_access(ctx)`:
+  - Return immediately when `ctx.ssh_keys_path` is `None`.
+  - Parse the file as a JSON array of public key strings; write them one per line to `<target>/home/<user>/.ssh/authorized_keys`.
+  - `.ssh` at `0700`, `authorized_keys` at `0600`, both owned by the user via `arch-chroot <target> chown -R <user>:<user>`. Do not hardcode uid 1000 as PR #72 did — ask the target for it.
+  - A malformed or empty `ssh.json` must fail the phase loudly. A machine that installs "successfully" and is then unreachable is worse than one that stops with an error on screen.
+- `main.py`: register `("Configuring remote access", configure_remote_access)` in `build_phases` after `configure_login` (`:52`) and before `validate_boot`.
+
+### Model to follow
+`configure_login` (`phases_impl.py:1251`) — direct writes against `ctx.target`, `arch-chroot` reserved for ownership and `systemctl`. Match its structure.
+
+### Acceptance criteria
+- Install with `ssh.json`: `ssh <user>@<vm>` works with the corresponding private key on first boot, no password.
+- Install without `ssh.json`: phase runs, does nothing, install unaffected; `~/.ssh` is not created.
+- `authorized_keys` is `0600` and owned by the install user, not root.
+- Password SSH auth is left at the distro default — autoinstall does not enable it.
+- Interactive installs are unaffected: the flag is passed but the file never exists.
+
+---
+
+## 4) Documentation
+
+### File
+- `README.md`
+
+### Changes
+- New "Autoinstall" section covering: what the `cidata` drive is, the file table, how to produce the drive, and a Proxmox `qm create` example with disk-first boot order so the empty disk falls through to the ISO on the first boot and boots the installed system afterward.
+- Show `openssl passwd -6` for the credential hash and the `ssh.json` array format.
+- State plainly that the config files are the configurator's own output — the documented way to get a starting `user_configuration.json` is to run one interactive install and copy what it wrote.
+- Do not repeat PR #72's networking claims. Say that sshd and NetworkManager come enabled on a stock install and that autoinstall only adds the key.
+
+---
+
+## 5) Validation
+
+### Manual matrix
+1. Build the ISO from this branch.
+2. Interactive control run: boot with no `cidata` drive, install normally, confirm nothing changed.
+3. Autoinstall run on Proxmox: attach ISO + `cidata` drive, boot, no input; confirm the configurator never renders, the install completes, the machine reboots on its own, and SSH with the key works against the booted system.
+4. Encrypted autoinstall: `user_encrypt_installation.txt` set true; confirm the LUKS prompt appears on boot (this is the one autoinstall case that still needs a human at first boot — document it).
+5. Full Packer cycle: build, destroy, rebuild from the same `cidata` drive; confirm reproducibility.
+
+### Negative tests
+- Drive labeled `cidata` with no files → configurator runs.
+- Drive with `user_configuration.json` only → configurator runs.
+- Malformed `ssh.json` → install stops in the remote-access phase with a visible error, does not reboot into an unreachable machine.
+- Install failure under autoinstall (e.g. a disk target that does not exist) → failure screen renders, process exits non-zero, no hang.
+
+### Regression surface
+The interactive path shares every line of this change except the `load_cidata` branch, so run the standard acceptance harness (`./bin/omarchy-iso-test`) on the built ISO before proposing the PR.
+
+---
+
+## Relationship to PR #72
+
+PR #72 targeted the pre-`quattro` tree and cannot be rebased: `use_omarchy_helpers`, `run_configurator`, `install_arch`, `install_omarchy`, and `chroot_bash` no longer exist. This plan reimplements the same feature against the current tree and drops three things that PR deliberately flagged as questionable:
+
+- The `finished.sh` `sed` — replaced by section 2. The dashboard renders the reboot prompt now.
+- The `systemd-networkd` DHCP unit — unnecessary; NetworkManager is already enabled and would contend with it.
+- The `PasswordAuthentication yes` rewrite — unnecessary and a security downgrade.
+
+`load_cidata` is the one piece that carries over close to intact.


### PR DESCRIPTION
In collaboration with my favourite robot, we migrated #72 to quattro.

## What

The shipped ISO now installs itself with no keyboard when it finds a drive labeled `cidata` carrying the configurator's own output files. It copies them into `/root`, skips the wizard, and everything downstream runs the ordinary path against ordinary inputs. With no such drive, nothing changes and the configurator runs as it does today.

Three pieces, all small:

- `load_cidata` in `.automated_script.sh` finds the drive and stands in for `./configurator`. The required pair is the same one the orchestrator treats as mandatory, so a drive with less than that falls back to the wizard rather than failing the boot.
- The dashboard owns the two prompts that outlive an install — the reboot confirm and the failure menu — and both read from the TTY, so both hang forever on a headless VM. `OMARCHY_UI_INTERACTIVE=no` suppresses them in the one process that owns the visible UI, rather than patching prompts out of the scripts they live in.
- A `configure_ssh_access` orchestrator phase installs the keys from an optional `ssh.json`, enables `sshd`, and opens port 22. All three are needed: Omarchy ships openssh with the service disabled, and `install/config/firewall.sh` opens LocalSend and docker DNS but never 22, so keys alone leave the machine pingable with SSH timing out. On interactive installs the flag is passed but the file never exists, so the phase is a no-op.

`plans/autoinstall.md` records the design and the reasoning behind each choice.

## Why

This supersedes #72, which was written against the pre-`quattro` tree and could not be rebased — `use_omarchy_helpers`, `run_configurator`, `install_arch`, `install_omarchy`, and `chroot_bash` are all gone. Rewritten against the configurator/dashboard/orchestrator split as @dhh asked.

The motivation is unchanged: using the ISO with Packer and Proxmox for disposable dev environments, which needs Omarchy installs that can be spun up and torn down without manual interaction.

Three things #72 was rightly criticised for are gone. The `finished.sh` `sed` is unnecessary — the dashboard renders the reboot prompt itself now. The `systemd-networkd` DHCP unit is unnecessary and would have contended with NetworkManager, which is already enabled with DHCP. The `PasswordAuthentication yes` rewrite is a security downgrade; key auth is the only thing added.

## Testing

Three install cycles on a Proxmox host, plus unit coverage for `load_cidata` (8 cases) and `configure_ssh_access` (11 cases).

The final run, from a wiped disk with no intervention: boot, configurator skipped, install, automatic reboot into SDDM, then `ssh -i key jeff@vm` connects. `~/.ssh` is `0700` and `authorized_keys` `0600`, both owned by the user; `sshd`, NetworkManager and ufw are enabled and active; hostname, timezone and git identity all come from the cidata files.

Regression check: the same ISO with the cidata drive detached boots straight into the configurator.

An earlier run failed the SSH phase, which usefully exercised the non-interactive failure path — the dashboard rendered the failure screen and exited rather than blocking on `gum choose`.

Not tested: encrypted autoinstall, which is not fully unattended anyway since the LUKS passphrase prompt still needs someone at first boot; and a full Packer build/destroy/rebuild cycle.

One note for whoever touches it next: `manifests/fresh-4-semantic.json` claims `sshd.service: enabled` and carries an `allow tcp 22` ufw rule. Neither is true of a stock install of this ISO. Trusting it over a real install cost two test cycles here.