### PR TITLE
Confirm the Start Omarchy Now prompt after provisioning setup

### DIFF
--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -788,6 +788,15 @@ wait_for_install() {
       return 0
     fi
 
+    # Deferred-provisioning installs skip the celebration and reboot on their own
+    # (no Reboot Now prompt); the first-boot greeter tagline appearing means the
+    # install finished and rebooted into setup.
+    if $PROVISION && grep -qi "Opinionated" <<<"$text"; then
+      log "Install finished and auto-rebooted into first-boot setup."
+      capture_console "success-installer-15-autoreboot"
+      return 0
+    fi
+
     if grep -qi "installation stopped" <<<"$text"; then
       capture_console "failure-installer-installation-stopped"
       echo "Install failed — screenshot saved to $RUN_DIR" >&2

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -753,18 +753,24 @@ drive_provision_owner() {
   capture_console "success-provision-04-email"
   press ret
 
+  # Hostname is deferred to first boot too.
+  wait_for_screen "Hostname" 60
+  type_text "$GUEST_HOSTNAME"
+  capture_console "success-provision-05-hostname"
+  press ret
+
   # Timezone is deferred to first boot too; accept the geo-guessed default.
   wait_for_screen "Timezone" 60
-  capture_console "success-provision-05-timezone"
+  capture_console "success-provision-06-timezone"
   press ret
 
   wait_for_screen "look right" 60
-  capture_console "success-provision-06-review"
+  capture_console "success-provision-07-review"
   press ret
 
   # Finalization (offline Node unpack, LUKS re-key on encrypted installs)
   # runs before SDDM appears.
-  capture_console "success-provision-07-finalizing"
+  capture_console "success-provision-08-finalizing"
 }
 
 wait_for_install() {
@@ -991,9 +997,25 @@ install_phase() {
       ((waited += 10))
     done
 
+    # The owner's hostname and timezone are set at first boot now, not baked
+    # into the install — confirm they actually landed on the running system.
+    local got_host got_tz
+    got_host=$(ssh_guest "cat /etc/hostname" 2>/dev/null | tr -d '\r\n')
+    got_tz=$(ssh_guest "timedatectl show -p Timezone --value" 2>/dev/null | tr -d '\r\n')
+    if [[ $got_host == "$GUEST_HOSTNAME" ]]; then
+      log "hostname applied at first boot: $got_host"
+    else
+      echo "WARN: hostname is '${got_host:-<empty>}', expected '$GUEST_HOSTNAME'" >&2
+    fi
+    if [[ -n $got_tz && $got_tz != "UTC" ]]; then
+      log "timezone applied at first boot: $got_tz"
+    else
+      echo "WARN: timezone is '${got_tz:-<empty>}' (expected the owner's choice, not UTC)" >&2
+    fi
+
     # Deferred first-boot setup hands straight off to SDDM once the oneshot
     # service exits — no celebration screen, no Start Omarchy button to confirm.
-    capture_console "success-provision-08-handoff"
+    capture_console "success-provision-09-handoff"
   fi
 
   ssh_guest "echo $GUEST_PASSWORD | sudo -S cat /var/log/omarchy-install-timing.json 2>/dev/null" \

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -753,13 +753,18 @@ drive_provision_owner() {
   capture_console "success-provision-04-email"
   press ret
 
+  # Timezone is deferred to first boot too; accept the geo-guessed default.
+  wait_for_screen "Timezone" 60
+  capture_console "success-provision-05-timezone"
+  press ret
+
   wait_for_screen "look right" 60
-  capture_console "success-provision-05-review"
+  capture_console "success-provision-06-review"
   press ret
 
   # Finalization (offline Node unpack, LUKS re-key on encrypted installs)
   # runs before SDDM appears.
-  capture_console "success-provision-06-finalizing"
+  capture_console "success-provision-07-finalizing"
 }
 
 wait_for_install() {
@@ -986,12 +991,9 @@ install_phase() {
       ((waited += 10))
     done
 
-    # Setup ends on the celebration screen with a Start Omarchy Now button
-    # gating the SDDM handoff, so confirm it like the installer's Reboot Now.
-    log "Confirming the Start Omarchy Now prompt"
-    wait_for_screen "Start Omarchy Now" 120
-    capture_console "success-provision-06-setup-complete"
-    press ret
+    # Deferred first-boot setup hands straight off to SDDM once the oneshot
+    # service exits — no celebration screen, no Start Omarchy button to confirm.
+    capture_console "success-provision-08-handoff"
   fi
 
   ssh_guest "echo $GUEST_PASSWORD | sudo -S cat /var/log/omarchy-install-timing.json 2>/dev/null" \

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -975,7 +975,13 @@ install_phase() {
       sleep 10
       ((waited += 10))
     done
+
+    # Setup ends on the celebration screen with a Start Omarchy Now button
+    # gating the SDDM handoff, so confirm it like the installer's Reboot Now.
+    log "Confirming the Start Omarchy Now prompt"
+    wait_for_screen "Start Omarchy Now" 120
     capture_console "success-provision-06-setup-complete"
+    press ret
   fi
 
   ssh_guest "echo $GUEST_PASSWORD | sudo -S cat /var/log/omarchy-install-timing.json 2>/dev/null" \

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -760,7 +760,8 @@ drive_provision_owner() {
   press ret
 
   # Timezone is deferred to first boot too; accept the geo-guessed default.
-  wait_for_screen "Timezone" 60
+  # Generous timeout: the tzupdate geo-guess over first-boot networking can lag.
+  wait_for_screen "Timezone" 180
   capture_console "success-provision-06-timezone"
   press ret
 
@@ -986,8 +987,15 @@ install_phase() {
   # flag to clear before powering off.
   if $PROVISION; then
     log "Waiting for provisioning first-boot setup to finish"
-    local waited=0
-    while ssh_guest "test -f /var/lib/omarchy/provisioning/pending" 2>/dev/null; do
+    local waited=0 rc
+    while true; do
+      ssh_guest "test -f /var/lib/omarchy/provisioning/pending" 2>/dev/null
+      rc=$?
+      # rc 0 = flag still present; rc 255 = SSH not up yet (finalization may
+      # still be running) — keep waiting. Only a clean "file absent" (rc 1)
+      # means provisioning finished, so we don't snapshot mid-finalization on a
+      # transient SSH blip.
+      (( rc == 0 || rc == 255 )) || break
       if ((waited >= 900)); then
         capture_console "failure-provision-finalization-timeout"
         echo "Timed out waiting for provisioning first-boot setup to complete" >&2
@@ -999,14 +1007,17 @@ install_phase() {
 
     # The owner's hostname and timezone are set at first boot now, not baked
     # into the install — confirm they actually landed on the running system.
+    # Hostname is deterministic (we typed it), so a mismatch is a hard failure;
+    # timezone is geo-guessed, so just report what landed.
     local got_host got_tz
     got_host=$(ssh_guest "cat /etc/hostname" 2>/dev/null | tr -d '\r\n')
     got_tz=$(ssh_guest "timedatectl show -p Timezone --value" 2>/dev/null | tr -d '\r\n')
-    if [[ $got_host == "$GUEST_HOSTNAME" ]]; then
-      log "hostname applied at first boot: $got_host"
-    else
-      echo "WARN: hostname is '${got_host:-<empty>}', expected '$GUEST_HOSTNAME'" >&2
+    if [[ $got_host != "$GUEST_HOSTNAME" ]]; then
+      capture_console "failure-provision-hostname-not-applied"
+      echo "First-boot hostname is '${got_host:-<empty>}', expected '$GUEST_HOSTNAME'" >&2
+      return 1
     fi
+    log "hostname applied at first boot: $got_host"
     if [[ -n $got_tz && $got_tz != "UTC" ]]; then
       log "timezone applied at first boot: $got_tz"
     else

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -989,8 +989,10 @@ install_phase() {
     log "Waiting for provisioning first-boot setup to finish"
     local waited=0 rc
     while true; do
-      ssh_guest "test -f /var/lib/omarchy/provisioning/pending" 2>/dev/null
-      rc=$?
+      # Capture rc via `|| rc=$?` so a non-zero result doesn't trip `set -e`
+      # (this command is intentionally allowed to "fail" — that's the signal).
+      rc=0
+      ssh_guest "test -f /var/lib/omarchy/provisioning/pending" 2>/dev/null || rc=$?
       # rc 0 = flag still present; rc 255 = SSH not up yet (finalization may
       # still be running) — keep waiting. Only a clean "file absent" (rc 1)
       # means provisioning finished, so we don't snapshot mid-finalization on a
@@ -1009,9 +1011,9 @@ install_phase() {
     # into the install — confirm they actually landed on the running system.
     # Hostname is deterministic (we typed it), so a mismatch is a hard failure;
     # timezone is geo-guessed, so just report what landed.
-    local got_host got_tz
-    got_host=$(ssh_guest "cat /etc/hostname" 2>/dev/null | tr -d '\r\n')
-    got_tz=$(ssh_guest "timedatectl show -p Timezone --value" 2>/dev/null | tr -d '\r\n')
+    local got_host="" got_tz=""
+    got_host=$(ssh_guest "cat /etc/hostname" 2>/dev/null | tr -d '\r\n') || got_host=""
+    got_tz=$(ssh_guest "timedatectl show -p Timezone --value" 2>/dev/null | tr -d '\r\n') || got_tz=""
     if [[ $got_host != "$GUEST_HOSTNAME" ]]; then
       capture_console "failure-provision-hostname-not-applied"
       echo "First-boot hostname is '${got_host:-<empty>}', expected '$GUEST_HOSTNAME'" >&2

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -606,6 +606,11 @@ audio-panel|meta_l-ctrl-a|omarchy-keyboard-panel|omarchy.audio'
 drive_configurator() {
   log "Driving the installer wizard"
 
+  # A greeter (animated logo + tagline) opens the installer; Return begins.
+  wait_for_screen "Opinionated" 300
+  capture_console "success-installer-00-greeter"
+  press ret
+
   # Keyboard is the first screen. Ctrl+C there is the hidden entry into deferred provisioning
   # mode; a normal install just selects the layout.
   wait_for_screen "keyboard layout" 300
@@ -710,7 +715,12 @@ drive_provision_owner() {
   # verifier can prove the deferred step applied a non-default layout — UK
   # leaves every letter identical to US, so the typed password (sent as raw
   # keycodes) still matches the literal one the harness pipes to sudo.
-  wait_for_screen "keyboard layout" 600
+  # A greeter (animated logo + tagline) opens first boot; Return begins.
+  wait_for_screen "Opinionated" 600
+  capture_console "success-provision-00-greeter"
+  press ret
+
+  wait_for_screen "keyboard layout" 120
   press up
   capture_console "success-provision-01-keyboard-layout-uk"
   press ret

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -101,6 +101,14 @@ else
   ./configurator
 fi
 
+# Deferred-provisioning installs skip the celebration/reboot prompt and reboot on
+# their own — the owner completes setup at first boot. Signalled by the config's
+# defer_provisioning flag (interactive) or the defer-provisioning marker (cidata).
+if [[ -f /root/defer-provisioning ]] ||
+  grep -qE '"defer_provisioning"[[:space:]]*:[[:space:]]*true' /root/user_configuration.json 2>/dev/null; then
+  export OMARCHY_UI_DEFER_PROVISIONING=yes
+fi
+
 # The foreground dashboard is now the sole visible install UI owner. It starts
 # the actual installer as a non-interactive child, logs child output, waits for
 # completion, then renders the final installed-time/reboot prompt itself.

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -104,8 +104,10 @@ fi
 # Deferred-provisioning installs skip the celebration/reboot prompt and reboot on
 # their own — the owner completes setup at first boot. Signalled by the config's
 # defer_provisioning flag (interactive) or the defer-provisioning marker (cidata).
+# Parse the flag with jq (the same JSON semantics the orchestrator uses) rather
+# than a line regex, so a reformatted config can't read as a direct install.
 if [[ -f /root/defer-provisioning ]] ||
-  grep -qE '"defer_provisioning"[[:space:]]*:[[:space:]]*true' /root/user_configuration.json 2>/dev/null; then
+  [[ "$(jq -r '.omarchy_install.defer_provisioning // false' /root/user_configuration.json 2>/dev/null)" == "true" ]]; then
   export OMARCHY_UI_DEFER_PROVISIONING=yes
 fi
 

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -1032,11 +1032,10 @@ if $defer_provisioning; then
   password_hash=""
   full_name=""
   email_address=""
-  # Leave hostname and timezone unset: the owner picks them in the first-boot
-  # OOBE. The orchestrator skips an empty timezone (system stays UTC until then)
-  # and falls back to a neutral hostname for the install.
-  hostname=""
-  timezone=""
+  # Neutral defaults for the install; the owner overwrites both in the
+  # first-boot OOBE (omarchy-provision-owner).
+  hostname="omarchy"
+  timezone="UTC"
 
   # Jump straight to disk selection + overwrite confirmation (encrypted by
   # default, Ctrl+C toggles unencrypted). deferred provisioning is always a full-disk install.

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -71,6 +71,41 @@ clear_logo() {
   gum style --foreground 2 --padding "1 0 0 $PADDING_LEFT" "$(<"$LOGO_PATH")"
 }
 
+# Vertically-centered welcome shown once before the keyboard step — the same
+# frame the deferred-provisioning first boot opens on, so install and first boot
+# bookend the setup identically. Logo, the Omarchy tagline, and a single button,
+# centered like the boot logo. No animation.
+greeter() {
+  measure_terminal
+
+  local rows logo_h content_h top i
+  rows=$(stty size 2>/dev/null </dev/tty | awk '{print $1}')
+  [[ $rows =~ ^[0-9]+$ ]] || rows=${LINES:-24}
+  logo_h=$(wc -l <"$LOGO_PATH")
+
+  # logo + blank + tagline + blank + button (gum draws the button over ~2 rows).
+  content_h=$((logo_h + 5))
+  top=$(((rows - content_h) / 2))
+  (( top < 0 )) && top=0
+
+  printf "\033[H\033[2J"
+  for ((i = 0; i < top; i++)); do echo; done
+  gum style --foreground 2 --padding "0 0 0 $PADDING_LEFT" "$(<"$LOGO_PATH")"
+  echo
+
+  local tagline="Beautiful, Modern & Opinionated Linux by DHH"
+  local tpad=$(((TERM_WIDTH - ${#tagline}) / 2))
+  (( tpad < 0 )) && tpad=0
+  gum style --padding "0 0 0 $tpad" "$tagline"
+  echo
+
+  local btn="Start install"
+  local bpad=$(((TERM_WIDTH - ${#btn} - 8) / 2))
+  (( bpad < 0 )) && bpad=0
+  gum confirm --padding "0 0 0 $bpad" --show-help=false --default \
+    --affirmative "$btn" --negative "" "" || true
+}
+
 abort() {
   gum style "${1:-Aborted installation}"
   echo
@@ -974,6 +1009,8 @@ install_target="full_disk"
 # Let the live VT reach its settled width before the first screen so the logo
 # isn't measured against the transient 80-column boot console.
 wait_for_stable_terminal
+
+greeter
 
 keyboard_form true
 

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -106,9 +106,14 @@ greeter() {
   hpad=$(((cols - ${#hint}) / 2)); (( hpad < 0 )) && hpad=0
   printf '\033[%d;%dH\033[2m%s\033[0m' "$hint_row" "$((hpad + 1))" "$hint"
 
-  # Loop a ColorShift over the logo until Return. The effect reads from
-  # /dev/null so it never swallows the Return; --reuse-canvas paints upward
-  # from the saved cursor, anchored one row below the logo.
+  # ColorShift the logo: a green base (indexed color 2) with a cyan accent (6)
+  # drifting through, settling on green. Indexed ANSI colors, not hex — the
+  # framebuffer console can't render tte's truecolor faithfully (it crushes the
+  # palette to a muddy lavender), but the 16 indexed colors map to the Tokyo
+  # Night palette and render true. One long-running invocation (many cycles) so
+  # it never restarts — a restart is what flashed. The effect reads from
+  # /dev/null so it never swallows the Return; --reuse-canvas paints upward from
+  # the saved cursor, anchored one row below the logo.
   if command -v tte >/dev/null 2>&1; then
     printf '\033[%d;1H\0337' "$((logo_row + logo_h))"
     (
@@ -116,11 +121,13 @@ greeter() {
         tte -i "$LOGO_PATH" \
           --canvas-width "$cols" \
           --anchor-text c \
-          --frame-rate 100 \
+          --frame-rate 60 \
           --reuse-canvas \
           colorshift \
-          --gradient-stops 9ece6a 7dcfff 7aa2f7 bb9af7 f7768e e0af68 \
-          --cycles 2 --final-gradient-stops 9ece6a \
+          --gradient-stops 2 10 6 10 \
+          --gradient-frames 3 \
+          --cycles 1000 \
+          --final-gradient-stops 2 \
           </dev/null 2>/dev/null
         printf '\0338'
       done
@@ -130,7 +137,12 @@ greeter() {
 
   IFS= read -r _ </dev/tty || true
   [[ -n ${anim:-} ]] && { kill "$anim" 2>/dev/null; wait "$anim" 2>/dev/null; }
-  printf '\033[?25h'
+  # tte leaves the tty in raw/no-echo mode when killed; restore it or the gum
+  # prompts in the keyboard step that follows silently die.
+  stty sane </dev/tty 2>/dev/null || true
+  # Reset the screen so the leftover animation frame doesn't linger under the
+  # keyboard step that follows.
+  printf '\033[0m\033[H\033[2J\033[?25h'
 }
 
 abort() {

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -78,32 +78,57 @@ clear_logo() {
 greeter() {
   measure_terminal
 
-  local rows logo_h content_h top i
+  local rows logo_h content_h top cols logo_row tagline_row hint_row
+  local tagline hint tpad hpad anim
+  cols=$TERM_WIDTH
   rows=$(stty size 2>/dev/null </dev/tty | awk '{print $1}')
   [[ $rows =~ ^[0-9]+$ ]] || rows=${LINES:-24}
   logo_h=$(wc -l <"$LOGO_PATH")
 
-  # logo + blank + tagline + blank + button (gum draws the button over ~2 rows).
-  content_h=$((logo_h + 5))
+  # logo + blank + tagline + blank + hint
+  content_h=$((logo_h + 4))
   top=$(((rows - content_h) / 2))
   (( top < 0 )) && top=0
+  logo_row=$((top + 1))
+  tagline_row=$((top + logo_h + 2))
+  hint_row=$((top + logo_h + 4))
 
-  printf "\033[H\033[2J"
-  for ((i = 0; i < top; i++)); do echo; done
+  printf '\033[?25l\033[H\033[2J'
+
+  printf '\033[%d;1H' "$logo_row"
   gum style --foreground 2 --padding "0 0 0 $PADDING_LEFT" "$(<"$LOGO_PATH")"
-  echo
 
-  local tagline="Beautiful, Modern & Opinionated Linux by DHH"
-  local tpad=$(((TERM_WIDTH - ${#tagline}) / 2))
-  (( tpad < 0 )) && tpad=0
-  gum style --padding "0 0 0 $tpad" "$tagline"
-  echo
+  tagline="Beautiful, Modern & Opinionated Linux by DHH"
+  tpad=$(((cols - ${#tagline}) / 2)); (( tpad < 0 )) && tpad=0
+  printf '\033[%d;%dH%s' "$tagline_row" "$((tpad + 1))" "$tagline"
 
-  local btn="Start install"
-  local bpad=$(((TERM_WIDTH - ${#btn} - 8) / 2))
-  (( bpad < 0 )) && bpad=0
-  gum confirm --padding "0 0 0 $bpad" --show-help=false --default \
-    --affirmative "$btn" --negative "" "" || true
+  hint="Press Return to Start Install"
+  hpad=$(((cols - ${#hint}) / 2)); (( hpad < 0 )) && hpad=0
+  printf '\033[%d;%dH\033[2m%s\033[0m' "$hint_row" "$((hpad + 1))" "$hint"
+
+  # Loop a ColorShift over the logo until Return. The effect reads from
+  # /dev/null so it never swallows the Return; --reuse-canvas paints upward
+  # from the saved cursor, anchored one row below the logo.
+  if command -v tte >/dev/null 2>&1; then
+    printf '\033[%d;1H\0337' "$((logo_row + logo_h))"
+    (
+      while true; do
+        tte -i "$LOGO_PATH" \
+          --canvas-width "$cols" \
+          --anchor-text c \
+          --frame-rate 100 \
+          --reuse-canvas \
+          colorshift --cycles 2 --final-gradient-stops 9ece6a \
+          </dev/null 2>/dev/null
+        printf '\0338'
+      done
+    ) >/dev/tty 2>/dev/null &
+    anim=$!
+  fi
+
+  IFS= read -r _ </dev/tty || true
+  [[ -n ${anim:-} ]] && { kill "$anim" 2>/dev/null; wait "$anim" 2>/dev/null; }
+  printf '\033[?25h'
 }
 
 abort() {

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -188,7 +188,6 @@ keyboard_form() {
   keyboards=$'Azerbaijani|azerty
 Belarusian|by
 Belgian|be-latin1
-Bosnian|ba
 Bulgarian|bg-cp1251
 Croatian|croat
 Czech|cz
@@ -214,7 +213,6 @@ Irish|ie
 Italian|it
 Japanese|jp106
 Kazakh|kazakh
-Khmer (Cambodia)|khmer
 Kyrgyz|kyrgyz
 Lao|la-latin1
 Latvian|lv

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -116,22 +116,21 @@ greeter() {
   # the saved cursor, anchored one row below the logo.
   if command -v tte >/dev/null 2>&1; then
     printf '\033[%d;1H\0337' "$((logo_row + logo_h))"
-    (
-      while true; do
-        tte -i "$LOGO_PATH" \
-          --canvas-width "$cols" \
-          --anchor-text c \
-          --frame-rate 60 \
-          --reuse-canvas \
-          colorshift \
-          --gradient-stops 2 10 6 10 \
-          --gradient-frames 3 \
-          --cycles 1000 \
-          --final-gradient-stops 2 \
-          </dev/null 2>/dev/null
-        printf '\0338'
-      done
-    ) >/dev/tty 2>/dev/null &
+    # Run tte directly (not inside a `while` subshell) so $anim is tte's own
+    # PID: killing a wrapping subshell would orphan tte, which then keeps
+    # painting the logo over the keyboard step. --cycles is high enough that it
+    # never ends on its own before Return.
+    tte -i "$LOGO_PATH" \
+      --canvas-width "$cols" \
+      --anchor-text c \
+      --frame-rate 60 \
+      --reuse-canvas \
+      colorshift \
+      --gradient-stops 2 10 6 10 \
+      --gradient-frames 3 \
+      --cycles 1000 \
+      --final-gradient-stops 2 \
+      </dev/null >/dev/tty 2>/dev/null &
     anim=$!
   fi
 

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -1062,8 +1062,11 @@ if $defer_provisioning; then
   password_hash=""
   full_name=""
   email_address=""
-  hostname="omarchy"
-  timezone="UTC"
+  # Leave hostname and timezone unset: the owner picks them in the first-boot
+  # OOBE. The orchestrator skips an empty timezone (system stays UTC until then)
+  # and falls back to a neutral hostname for the install.
+  hostname=""
+  timezone=""
 
   # Jump straight to disk selection + overwrite confirmation (encrypted by
   # default, Ctrl+C toggles unencrypted). deferred provisioning is always a full-disk install.

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -42,14 +42,12 @@ measure_terminal
 # console and only grows once the kernel framebuffer/KMS takes over (noticeably
 # late in VMs). The logo is wider than 80 columns, so a first draw against that
 # transient narrow console wraps the logo ("smushed") and can't center it
-# (padding clamps to 0, so it hugs the left). Every later screen re-measures and
-# looks right, so this only bites the very first screen. Hold that first draw
-# until the width settles at (or above) the logo width. Terminal emulators (dry
-# runs) are already at final size, so skip them; a real VT that never widens
-# (e.g. nomodeset) still proceeds after the cap rather than hanging.
+# (padding clamps to 0, so it hugs the left). A terminal emulator (or sudo's
+# pty) has the same problem the other way: it reports a stale 24x80 for a few
+# hundred ms after start before its real winsize is set. Either way, hold the
+# first draw until the width settles at (or above) the logo width. A real VT
+# that never widens (e.g. nomodeset) still proceeds after the cap.
 wait_for_stable_terminal() {
-  [[ $(tty 2>/dev/null) == /dev/tty* ]] || return 0
-
   local width last="" stable=0 waited=0
   while (( waited < 5000 )); do
     width=$(stty size 2>/dev/null </dev/tty | awk '{print $2}')

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -77,7 +77,7 @@ greeter() {
   measure_terminal
 
   local rows logo_h content_h top cols logo_row tagline_row hint_row
-  local tagline hint tpad hpad
+  local tagline hint tpad hpad anim
   cols=$TERM_WIDTH
   rows=$(stty size 2>/dev/null </dev/tty | awk '{print $1}')
   [[ $rows =~ ^[0-9]+$ ]] || rows=${LINES:-24}
@@ -93,10 +93,6 @@ greeter() {
 
   printf '\033[?25l\033[H\033[2J'
 
-  # Logo in solid green (indexed color 2, which the framebuffer console renders
-  # stably). No tte color animation: tte emits 24-bit truecolor, which the
-  # console can only crush to its 16 flat colors, and consecutive frames crush
-  # to different ones — that frame-to-frame juddering was the greeter "flash".
   printf '\033[%d;1H' "$logo_row"
   gum style --foreground 2 --padding "0 0 0 $PADDING_LEFT" "$(<"$LOGO_PATH")"
 
@@ -108,8 +104,42 @@ greeter() {
   hpad=$(((cols - ${#hint}) / 2)); (( hpad < 0 )) && hpad=0
   printf '\033[%d;%dH\033[2m%s\033[0m' "$hint_row" "$((hpad + 1))" "$hint"
 
+  # ColorShift the logo: a green base (indexed color 2) with a cyan accent (6)
+  # drifting through, settling on green. Indexed ANSI colors, not hex — the
+  # framebuffer console can't render tte's truecolor faithfully (it crushes the
+  # palette to a muddy lavender), but the 16 indexed colors map to the Tokyo
+  # Night palette and render true. One long-running invocation (many cycles) so
+  # it never restarts — a restart is what flashed. The effect reads from
+  # /dev/null so it never swallows the Return; --reuse-canvas paints upward from
+  # the saved cursor, anchored one row below the logo.
+  if command -v tte >/dev/null 2>&1; then
+    printf '\033[%d;1H\0337' "$((logo_row + logo_h))"
+    # Run tte directly (not inside a `while` subshell) so $anim is tte's own
+    # PID: killing a wrapping subshell would orphan tte, which then keeps
+    # painting the logo over the keyboard step. --cycles is high enough that it
+    # never ends on its own before Return.
+    tte -i "$LOGO_PATH" \
+      --canvas-width "$cols" \
+      --anchor-text c \
+      --frame-rate 60 \
+      --reuse-canvas \
+      colorshift \
+      --gradient-stops 2 10 6 10 \
+      --gradient-frames 3 \
+      --cycles 1000 \
+      --final-gradient-stops 2 \
+      </dev/null >/dev/tty 2>/dev/null &
+    anim=$!
+  fi
+
   IFS= read -r _ </dev/tty || true
-  # Reset the screen so nothing lingers under the keyboard step that follows.
+  # Tolerate tte's kill signal in `wait` so a future `set -e` here can't abort.
+  [[ -n ${anim:-} ]] && { kill "$anim" 2>/dev/null; wait "$anim" 2>/dev/null || true; }
+  # tte leaves the tty in raw/no-echo mode when killed; restore it or the gum
+  # prompts in the keyboard step that follows silently die.
+  stty sane </dev/tty 2>/dev/null || true
+  # Reset the screen so the leftover animation frame doesn't linger under the
+  # keyboard step that follows.
   printf '\033[0m\033[H\033[2J\033[?25h'
 }
 

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -135,7 +135,8 @@ greeter() {
   fi
 
   IFS= read -r _ </dev/tty || true
-  [[ -n ${anim:-} ]] && { kill "$anim" 2>/dev/null; wait "$anim" 2>/dev/null; }
+  # Tolerate tte's kill signal in `wait` so a future `set -e` here can't abort.
+  [[ -n ${anim:-} ]] && { kill "$anim" 2>/dev/null; wait "$anim" 2>/dev/null || true; }
   # tte leaves the tty in raw/no-echo mode when killed; restore it or the gum
   # prompts in the keyboard step that follows silently die.
   stty sane </dev/tty 2>/dev/null || true

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -77,7 +77,7 @@ greeter() {
   measure_terminal
 
   local rows logo_h content_h top cols logo_row tagline_row hint_row
-  local tagline hint tpad hpad anim
+  local tagline hint tpad hpad
   cols=$TERM_WIDTH
   rows=$(stty size 2>/dev/null </dev/tty | awk '{print $1}')
   [[ $rows =~ ^[0-9]+$ ]] || rows=${LINES:-24}
@@ -93,6 +93,10 @@ greeter() {
 
   printf '\033[?25l\033[H\033[2J'
 
+  # Logo in solid green (indexed color 2, which the framebuffer console renders
+  # stably). No tte color animation: tte emits 24-bit truecolor, which the
+  # console can only crush to its 16 flat colors, and consecutive frames crush
+  # to different ones — that frame-to-frame juddering was the greeter "flash".
   printf '\033[%d;1H' "$logo_row"
   gum style --foreground 2 --padding "0 0 0 $PADDING_LEFT" "$(<"$LOGO_PATH")"
 
@@ -104,42 +108,8 @@ greeter() {
   hpad=$(((cols - ${#hint}) / 2)); (( hpad < 0 )) && hpad=0
   printf '\033[%d;%dH\033[2m%s\033[0m' "$hint_row" "$((hpad + 1))" "$hint"
 
-  # ColorShift the logo: a green base (indexed color 2) with a cyan accent (6)
-  # drifting through, settling on green. Indexed ANSI colors, not hex — the
-  # framebuffer console can't render tte's truecolor faithfully (it crushes the
-  # palette to a muddy lavender), but the 16 indexed colors map to the Tokyo
-  # Night palette and render true. One long-running invocation (many cycles) so
-  # it never restarts — a restart is what flashed. The effect reads from
-  # /dev/null so it never swallows the Return; --reuse-canvas paints upward from
-  # the saved cursor, anchored one row below the logo.
-  if command -v tte >/dev/null 2>&1; then
-    printf '\033[%d;1H\0337' "$((logo_row + logo_h))"
-    # Run tte directly (not inside a `while` subshell) so $anim is tte's own
-    # PID: killing a wrapping subshell would orphan tte, which then keeps
-    # painting the logo over the keyboard step. --cycles is high enough that it
-    # never ends on its own before Return.
-    tte -i "$LOGO_PATH" \
-      --canvas-width "$cols" \
-      --anchor-text c \
-      --frame-rate 60 \
-      --reuse-canvas \
-      colorshift \
-      --gradient-stops 2 10 6 10 \
-      --gradient-frames 3 \
-      --cycles 1000 \
-      --final-gradient-stops 2 \
-      </dev/null >/dev/tty 2>/dev/null &
-    anim=$!
-  fi
-
   IFS= read -r _ </dev/tty || true
-  # Tolerate tte's kill signal in `wait` so a future `set -e` here can't abort.
-  [[ -n ${anim:-} ]] && { kill "$anim" 2>/dev/null; wait "$anim" 2>/dev/null || true; }
-  # tte leaves the tty in raw/no-echo mode when killed; restore it or the gum
-  # prompts in the keyboard step that follows silently die.
-  stty sane </dev/tty 2>/dev/null || true
-  # Reset the screen so the leftover animation frame doesn't linger under the
-  # keyboard step that follows.
+  # Reset the screen so nothing lingers under the keyboard step that follows.
   printf '\033[0m\033[H\033[2J\033[?25h'
 }
 

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -118,7 +118,9 @@ greeter() {
           --anchor-text c \
           --frame-rate 100 \
           --reuse-canvas \
-          colorshift --cycles 2 --final-gradient-stops 9ece6a \
+          colorshift \
+          --gradient-stops 9ece6a 7dcfff 7aa2f7 bb9af7 f7768e e0af68 \
+          --cycles 2 --final-gradient-stops 9ece6a \
           </dev/null 2>/dev/null
         printf '\0338'
       done

--- a/configs/airootfs/usr/local/bin/omarchy-install-dashboard
+++ b/configs/airootfs/usr/local/bin/omarchy-install-dashboard
@@ -736,6 +736,17 @@ if (( status != 0 )); then
   exit "$failure_status"
 fi
 
+# Deferred-provisioning installs finish silently and reboot on their own — the
+# owner completes setup (and sees the send-off) at first boot, so the "Installed
+# Omarchy in ..." celebration and the Reboot Now prompt belong to a direct
+# install only.
+if [[ ${OMARCHY_UI_DEFER_PROVISIONING:-} == "yes" ]]; then
+  printf '%s' "$CLEAR" >"$TTY_PATH" 2>/dev/null || true
+  [[ ${OMARCHY_UI_AUTO_REBOOT:-} == "no" ]] && exit 0
+  reboot 2>/dev/null || systemctl reboot 2>/dev/null || true
+  exit 0
+fi
+
 set +e
 render_finish
 finish_render_status=$?

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -260,10 +260,7 @@ def arch_install_system(ctx: InstallContext) -> None:
                     if config.mirror_config else []
                 ),
                 mkinitcpio=False,
-                # Deferred-provisioning installs leave the hostname unset (the
-                # owner names the machine in the first-boot OOBE); give
-                # archinstall a neutral default so the install still succeeds.
-                hostname=config.hostname or "archlinux",
+                hostname=config.hostname,
                 locale_config=(
                     replace(config.locale_config, kb_layout="")
                     if config.locale_config else None

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -260,7 +260,10 @@ def arch_install_system(ctx: InstallContext) -> None:
                     if config.mirror_config else []
                 ),
                 mkinitcpio=False,
-                hostname=config.hostname,
+                # Deferred-provisioning installs leave the hostname unset (the
+                # owner names the machine in the first-boot OOBE); give
+                # archinstall a neutral default so the install still succeeds.
+                hostname=config.hostname or "archlinux",
                 locale_config=(
                     replace(config.locale_config, kb_layout="")
                     if config.locale_config else None


### PR DESCRIPTION
Companion to basecamp/omarchy#6631: first-boot account setup now ends on the install-style celebration screen with a **Start Omarchy Now** button gating the SDDM handoff. The provisioning test must confirm that prompt once the pending flag clears — the same way it already confirms the installer's Reboot Now prompt — or the run would hang waiting for the session.

— 🤖 Claude, posting on behalf of @dhh
