### PR TITLE
Fix applesmc crash on pre t2 macs

### DIFF
--- a/configs/airootfs/etc/modprobe.d/blacklist-applesmc.conf
+++ b/configs/airootfs/etc/modprobe.d/blacklist-applesmc.conf
@@ -1,0 +1,3 @@
+# linux-t2 ships for every machine, and on a pre-T2 Mac its applesmc oopses
+# registering the keyboard-backlight LED, wedging udev. Nothing here needs the SMC.
+blacklist applesmc

--- a/configs/airootfs/usr/local/bin/omarchy-iso-cleanup-disk
+++ b/configs/airootfs/usr/local/bin/omarchy-iso-cleanup-disk
@@ -10,6 +10,21 @@
 
 set -uo pipefail
 
+# These probes can wedge in the kernel where not even SIGKILL lands, so don't
+# wait on them — `timeout` would just block in wait() alongside. Abandon and move
+# on; a disk we can't inspect is one archinstall is about to wipe anyway.
+run_bounded() {
+  local bound=${OMARCHY_CLEANUP_TIMEOUT:-10} out pid deadline
+  out=$(mktemp)
+  "$@" >"$out" 2>/dev/null &
+  pid=$!
+  deadline=$((SECONDS + bound))
+  while ((SECONDS < deadline)) && kill -0 "$pid" 2>/dev/null; do sleep 0.05; done
+  kill -TERM "$pid" 2>/dev/null && echo "  gave up on '$*' after ${bound}s" >&2
+  cat "$out"
+  rm -f "$out"
+}
+
 if [[ ${1:-} == --protected ]]; then
   target="${2:-}"
   [[ -n $target ]] || { echo "Usage: $0 --protected <target>" >&2; exit 1; }
@@ -31,17 +46,26 @@ while read -r dev; do
   done < <(findmnt -rn -S "$dev" -o TARGET 2>/dev/null || true)
 done < <(lsblk -rnpo PATH "$disk")
 
+pvdevs=()
 while read -r dev type; do
-  [[ $type == disk || $type == part || $type == crypt ]] || continue
+  [[ $type == disk || $type == part || $type == crypt ]] && pvdevs+=("$dev")
+done < <(lsblk -rnpo PATH,TYPE "$disk")
+
+# One pvs for every device at once, so a wedged LVM costs one bound and not one
+# per partition.
+if ((${#pvdevs[@]})); then
   while read -r vg; do
-    [[ -n $vg ]] && vgchange -an "$vg" 2>/dev/null || true
-  done < <(pvs --noheadings -o vg_name "$dev" 2>/dev/null | awk '{$1=$1; print}' | sort -u)
-done < <(lsblk -rnpo PATH,TYPE "$disk")
+    [[ -n $vg ]] || continue
+    run_bounded vgchange -an "$vg"
+  done < <(run_bounded pvs --noheadings -o vg_name "${pvdevs[@]}" | sort -u)
+fi
 
 while read -r dev type; do
-  [[ $type == crypt ]] && cryptsetup close "$dev" 2>/dev/null || true
+  [[ $type == crypt ]] || continue
+  run_bounded cryptsetup close "$dev"
 done < <(lsblk -rnpo PATH,TYPE "$disk")
 
-blockdev --flushbufs "$disk" 2>/dev/null || true
-partprobe "$disk" 2>/dev/null || true
-udevadm settle || true
+run_bounded blockdev --flushbufs "$disk"
+run_bounded partprobe "$disk"
+# settle defaults to 120s, which is a long time to sit on a blank screen.
+udevadm settle --timeout=10 || true

--- a/test/cleanup-disk-timeout-test.sh
+++ b/test/cleanup-disk-timeout-test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# omarchy-iso-cleanup-disk runs from a phase with check=True, so a probe that
+# never returns is an install that never returns — and the screen says only
+# "Cleaning up existing holders on install disk" while it happens. These cases
+# pin the bound that stops that.
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+CLEANUP="$ROOT/configs/airootfs/usr/local/bin/omarchy-iso-cleanup-disk"
+
+pass() { printf 'ok - %s\n' "$1"; }
+
+fail() {
+  local description="$1" detail="${2:-}"
+  [[ -n $detail ]] && printf '%s\n' "$detail" >&2
+  printf 'not ok - %s\n' "$description" >&2
+  exit 1
+}
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+stub_dir="$work/stubs"
+mkdir -p "$stub_dir"
+
+# A disk with one partition and nothing else on it.
+cat >"$stub_dir/lsblk" <<'STUB'
+#!/bin/bash
+echo "/dev/testdisk disk"
+echo "/dev/testdisk1 part"
+STUB
+
+# The wedged probe: LVM blocked on a global mutex some other driver is stuck
+# under. That state takes no signal at all, so the stub ignores SIGTERM — a plain
+# sleep would pass this test against an implementation that still hangs for real.
+cat >"$stub_dir/pvs" <<'STUB'
+#!/bin/bash
+printf 'pvs called\n' >>"$TEST_LOG"
+trap "" TERM
+sleep 300
+STUB
+
+for tool in findmnt umount swapoff vgchange cryptsetup blockdev partprobe udevadm; do
+  cat >"$stub_dir/$tool" <<STUB
+#!/bin/bash
+printf '$tool %s\n' "\$*" >>"\$TEST_LOG"
+exit 0
+STUB
+done
+chmod +x "$stub_dir"/*
+
+export TEST_LOG="$work/calls.log"
+: >"$TEST_LOG"
+
+# The script guards on [[ -b ]], which no stub can satisfy, so borrow whatever
+# block device this host has. Nothing is read from it: every tool that would
+# touch it is stubbed above.
+disk=""
+for candidate in /dev/loop0 /dev/sda /dev/vda /dev/nvme0n1 /dev/disk0; do
+  [[ -b $candidate ]] && { disk="$candidate"; break; }
+done
+if [[ -z $disk ]]; then
+  printf 'ok - skipped: no block device on this host to pass the -b guard\n'
+  exit 0
+fi
+
+start=$SECONDS
+status=0
+PATH="$stub_dir:$PATH" OMARCHY_CLEANUP_TIMEOUT=2 bash "$CLEANUP" "$disk" >"$work/out" 2>&1 || status=$?
+elapsed=$(( SECONDS - start ))
+
+grep -q 'pvs called' "$TEST_LOG" || fail "the test actually exercised the LVM probe" "$(cat "$TEST_LOG")"
+(( elapsed < 60 )) || fail "a wedged probe no longer hangs the install" "took ${elapsed}s"
+pass "a wedged LVM probe is bounded rather than hanging the install"
+
+(( status == 0 )) || fail "cleanup still succeeds despite a probe timing out" "exit $status"
+pass "a timed-out probe does not fail the install"
+
+# The whole point is that a stall is explicable, so it has to say something.
+grep -q 'gave up' "$work/out" || fail "abandoning a probe is reported" "$(cat "$work/out")"
+pass "an abandoned probe says so"
+
+# udevadm settle defaults to 120s; on a blank screen that reads as a hang.
+grep -q 'udevadm settle --timeout' "$CLEANUP" ||
+  fail "udevadm settle carries an explicit timeout"
+pass "udevadm settle is bounded"


### PR DESCRIPTION
Closes #101 

The ISO ships linux-t2 for every machine. On a pre-T2 Mac its applesmc oopses while registering the keyboard-backlight LED, which kills the udev worker mid-init while it holds locks. LVM then blocks forever opening /dev/mapper/control, and the install stops at "Cleaning up existing holders on install disk" with nothing on screen to say why.

Two changes:

- Blacklist applesmc in the live environment. Nothing in the installer needs the SMC, and the installed system still loads it normally.
- Bound the disk-cleanup probes so no single wedged one can hang the install. Note this can't be timeout(1) — the stuck process is in uninterruptible sleep, so it takes no signal, and timeout just blocks in waitpid next to it. run_bounded runs the probe in the background and abandons it at the deadline instead. pvs now gets every device in one call, so a systemically wedged LVM costs one 10s bound rather than one per partition.

Tested on the MacBookPro11,4 that hit this. test/cleanup-disk-timeout-test.sh covers the bound; its stub ignores SIGTERM, so it fails against a timeout-based implementation rather than passing on a technicality.r