### PR TITLE
Tell BitLocker users to decrypt, not suspend

### DIFF
--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -507,8 +507,9 @@ run_partition_decide() {
   bl_part=$(detect_bitlocker || true)
   if [[ -n "$bl_part" ]]; then
     say --foreground 1 "BitLocker signature detected on $bl_part."
-    say "Suspend or disable BitLocker in Windows before installing alongside it."
-    abort "Aborted: BitLocker is active on this disk."
+    say "Turn BitLocker off in Windows and wait for the drive to finish decrypting, then try again."
+    say "Suspending BitLocker is not enough — the drive stays encrypted."
+    abort "Aborted: BitLocker is enabled on this disk."
   fi
 
   # Omarchy always creates its own dedicated ESP in free space and never


### PR DESCRIPTION
The free-space install path detects BitLocker by the `-FVE-FS-` signature at offset 3 of each partition. Suspending BitLocker in Windows leaves that signature in place — the volume stays encrypted and only gains a clear-key protector — so a suspended volume aborts the install exactly like an active one. The old message told users to "suspend or disable", sending them down a path that could never work.

Aborting on suspended BitLocker is deliberate policy (`plans/protected-partition-install.md`), so this is a wording fix only, no change to detection or behaviour.

Also switched the abort line from "BitLocker is active" to "BitLocker is enabled", which reads as accurate to someone who just suspended it.

Fixes #99

— 🤖 Claude, posting on behalf of @dhh